### PR TITLE
Issue #15: enable integration test, generate package for zowe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ bin/
 
 ### Mac ###
 .DS_Store
+
+### Temporary Certificate###
+*.p12

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,31 @@ if (BRANCH_NAME == MASTER_BRANCH) {
     opts.push(buildDiscarder(logRotator(numToKeepStr: '5')))
 }
 
+// define custom build parameters
+def customParameters = []
+customParameters.push(string(
+  name: 'INTEGRATION_TEST_ZOSMF_HOST',
+  description: 'z/OSMF server for integration test',
+  defaultValue: 'river.zowe.org',
+  trim: true,
+  required: true
+))
+customParameters.push(string(
+  name: 'INTEGRATION_TEST_ZOSMF_PORT',
+  description: 'z/OSMF port for integration test',
+  defaultValue: '10443',
+  trim: true,
+  required: true
+))
+customParameters.push(credentials(
+  name: 'INTEGRATION_TEST_ZOSMF_CREDENTIAL',
+  description: 'z/OSMF credential for integration test',
+  credentialType: 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl',
+  defaultValue: 'ssh-zdt-test-image-guest',
+  required: true
+))
+opts.push(parameters(customParameters))
+
 properties(opts)
 
 pipeline {
@@ -182,11 +207,11 @@ pipeline {
         /************************************************************************
          * STAGE
          * -----
-         * Run integration tests [ TODO: DISABLED ]
+         * Run integration tests
          *
          * TIMEOUT
          * -------
-         * 10 Minutes
+         * 20 Minutes
          *
          * EXECUTION CONDITIONS
          * --------------------
@@ -199,21 +224,108 @@ pipeline {
          *
          * OUTPUTS
          * -------
-         * None [ TODO: Add test reporting ]
+         * HTML test report: Integration Test Results
          ************************************************************************/
-        stage('Unit Test') {
+        stage('Integration Test') {
             when {
                 expression {
                     return SHOULD_BUILD == 'true'
                 }
                 expression {
-                	return 1 == 0
+                    return currentBuild.resultIsBetterOrEqualTo(BUILD_SUCCESS)
+                }
+            }
+            stages {
+                stage('Prepare Certificate') {
+                    steps {
+                        sh """keytool -genkeypair -keystore localhost.keystore.p12 -storetype PKCS12 \
+    -storepass password -alias localhost -keyalg RSA -keysize 2048 -validity 99999 \
+    -dname \"CN=Zowe Jobs Explorer API Default Certificate, OU=Zowe API Squad, O=Zowe, L=Hursley, ST=Hampshire, C=UK\" \
+    -ext san=dns:localhost,ip:127.0.0.1"""
+                    }
+                }
+
+                stage('Start Server') {
+                    steps {
+                        sh """java -Xms16m -Xmx512m -Dibm.serversocket.recover=true -Dfile.encoding=UTF-8 \
+    -Djava.io.tmpdir=/tmp \
+    -Dserver.port=8443 \
+    -Dserver.ssl.keyAlias=localhost \
+    -Dserver.ssl.keyStore=localhost.keystore.p12 \
+    -Dserver.ssl.keyStorePassword=password \
+    -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dzosmf.httpsPort=${params.INTEGRATION_TEST_ZOSMF_PORT} \
+    -Dzosmf.ipAddress=${params.INTEGRATION_TEST_ZOSMF_HOST} \
+    -jar \$(ls -1 jobs-api-server/build/libs/jobs-api-server-*.jar) &"""
+                        }
+                    }
+                }
+
+                stage('Start Test') {
+                    steps {
+                        timeout(time: 20, unit: 'MINUTES') {
+                            withCredentials([usernamePassword(credentialsId: params.INTEGRATION_TEST_ZOSMF_CREDENTIAL, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                sh """./gradlew runIntegrationTests \
+    -Pserver.host=localhost \
+    -Pserver.port=8443 \
+    -Pserver.username=${USERNAME} \
+    -Pserver.password=${PASSWORD}"""
+                            }
+                        }
+
+                        publishHTML(target: [
+                            allowMissing         : false,
+                            alwaysLinkToLastBuild: false,
+                            keepAll              : true,
+                            reportDir            : 'jobs-tests/build/reports/tests/test',
+                            reportFiles          : 'index.html',
+                            reportName           : "Integration Test Results"
+                        ])
+                    }
+                }
+            }
+        }
+
+        /************************************************************************
+         * STAGE
+         * -----
+         * Package
+         *
+         * TIMEOUT
+         * -------
+         * 5 Minutes
+         *
+         * EXECUTION CONDITIONS
+         * --------------------
+         * - SHOULD_BUILD is true
+         * - The current branch is MASTER branch or a RELEASE_BRANCH
+         * - The build is still successful and not unstable
+         *
+         * DESCRIPTION
+         * -----------
+         * Pacakge the current build as a zip file for zowe integration.
+         *
+         * OUTPUTS
+         * -------
+         * zip package
+         ************************************************************************/
+        stage('Package') {
+            when {
+                allOf {
+                    expression {
+                        return SHOULD_BUILD == 'true'
+                    }
+                    expression {
+                        return currentBuild.resultIsBetterOrEqualTo(BUILD_SUCCESS)
+                    }
+                    expression {
+                        return BRANCH_NAME.equals(MASTER_BRANCH) || RELEASE_BRANCH;   
+                    }
                 }
             }
             steps {
-                timeout(time: 10, unit: 'MINUTES') {
-                    echo 'Run Integration Tests'
-                    sh './gradlew runIntegrationTests'
+                timeout(time: 5, unit: 'MINUTES') {
+                    sh './gradlew packageJobsApiServer'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -264,22 +264,30 @@ pipeline {
                     steps {
                         timeout(time: 20, unit: 'MINUTES') {
                             withCredentials([usernamePassword(credentialsId: params.INTEGRATION_TEST_ZOSMF_CREDENTIAL, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                sh """./gradlew runIntegrationTests \
+                                catchError {
+                                    sh """./gradlew runIntegrationTests \
     -Pserver.host=localhost \
     -Pserver.port=8443 \
     -Pserver.username=${USERNAME} \
     -Pserver.password=${PASSWORD}"""
+                                }
+
+                                publishHTML(target: [
+                                    allowMissing         : false,
+                                    alwaysLinkToLastBuild: false,
+                                    keepAll              : true,
+                                    reportDir            : 'jobs-tests/build/reports/tests/test',
+                                    reportFiles          : 'index.html',
+                                    reportName           : "Integration Test Results"
+                                ])
+                                
+                                // FIXME: after fixed all integeration test failures, un-comment
+                                //        below check to exit pipeline if test failed
+                                // if (currentBuild.isWorseThan(BUILD_SUCCESS)) {
+                                //     error "Integeration test failed"
+                                // }
                             }
                         }
-
-                        publishHTML(target: [
-                            allowMissing         : false,
-                            alwaysLinkToLastBuild: false,
-                            keepAll              : true,
-                            reportDir            : 'jobs-tests/build/reports/tests/test',
-                            reportFiles          : 'index.html',
-                            reportName           : "Integration Test Results"
-                        ])
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,7 +257,6 @@ pipeline {
     -Dzosmf.httpsPort=${params.INTEGRATION_TEST_ZOSMF_PORT} \
     -Dzosmf.ipAddress=${params.INTEGRATION_TEST_ZOSMF_HOST} \
     -jar \$(ls -1 jobs-api-server/build/libs/jobs-api-server-*.jar) &"""
-                        }
                     }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,6 +257,9 @@ pipeline {
     -Dzosmf.httpsPort=${params.INTEGRATION_TEST_ZOSMF_PORT} \
     -Dzosmf.ipAddress=${params.INTEGRATION_TEST_ZOSMF_HOST} \
     -jar \$(ls -1 jobs-api-server/build/libs/jobs-api-server-*.jar) &"""
+
+                        // give it a little time to start the server
+                        sleep time: 1, unit: 'MINUTES'
                     }
                 }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,76 @@
-# atlas-datasets-tests
+# Explorer Jobs API
 
 [![Code Quality](https://jayne.zowe.org:9000/api/project_badges/measure?project=explorer%3Ajobs-api-server&metric=alert_status)](https://jayne.zowe.org:9000/dashboard/index/explorer:jobs-api-server)
+
+## Build
+
+```
+./gradlew build
+```
+
+## SonarQube Static Code Scan
+
+```
+./gradlew --info sonarqube -Psonar.host.url=${SONAR_HOST_URL}
+```
+
+*Note: please replace the `${SONAR_HOST_URL}` variable in above with your SonarQube server URL.
+
+## Test
+
+### Unit Test
+
+```
+./gradlew test
+```
+
+### Integration Test
+
+- Generate test certificate
+
+  ```
+  keytool -genkeypair -keystore localhost.keystore.p12 -storetype PKCS12 \
+      -storepass password -alias localhost -keyalg RSA -keysize 2048 -validity 99999 \
+      -dname \"CN=Zowe Jobs Explorer API Default Certificate, OU=Zowe API Squad, O=Zowe, L=Hursley, ST=Hampshire, C=UK\" \
+      -ext san=dns:localhost,ip:127.0.0.1
+  ```
+
+- Start test server
+
+  ```
+  java -Xms16m -Xmx512m -Dibm.serversocket.recover=true -Dfile.encoding=UTF-8 \
+    -Djava.io.tmpdir=/tmp \
+    -Dserver.port=8443 \
+    -Dserver.ssl.keyAlias=localhost \
+    -Dserver.ssl.keyStore=localhost.keystore.p12 \
+    -Dserver.ssl.keyStorePassword=password \
+    -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dzosmf.httpsPort=${ZOSMF_PORT} \
+    -Dzosmf.ipAddress=${ZOSMF_HOST} \
+    -jar $(ls -1 jobs-api-server/build/libs/jobs-api-server-*.jar) &
+  ```
+
+  *Note: please replace the `${ZOSMF_PORT}` and `${ZOSMF_HOST}` variable in above with your z/OSMF server information.
+
+- Run integration test
+
+  ```
+  ./gradlew runIntegrationTests \
+    -Pserver.host=localhost \
+    -Pserver.port=8443 \
+    -Pserver.username=${USERNAME} \
+    -Pserver.password=${PASSWORD}
+  ```
+
+  *Note: please replace the `${USERNAME}` and `${PASSWORD}` variable in above with your z/OSMF server information.
+
+## Package and Deploy
+
+```
+# packaging for Zowe
+./gradlew packageJobsApiServer
+# deploy artifact
+./gradlew publishArtifacts --info -Pdeploy.username=${USERNAME} -Pdeploy.password=${PASSWORD}
+```
+
+*Note: please replace the `${USERNAME}` and `${PASSWORD}` variable in above with your artifactory account information.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,7 +3,7 @@ ext {
     springBootVersion = '2.0.4.RELEASE'
     springFoxVersion = '2.8.0'
     lombokVersion = '1.16.20'
-    mockitoCoreVersion = '2.9.0'
+    mockitoCoreVersion = '2.23.4'
     powerMockVersion = "2.0.0-RC.1"
     gsonVersion = '2.8.2'
     httpClientVersion = '4.5.3'

--- a/jobs-zowe-server-package/src/main/resources/scripts/jobs-api-server-start.sh
+++ b/jobs-zowe-server-package/src/main/resources/scripts/jobs-api-server-start.sh
@@ -19,12 +19,12 @@ fi
 DIR=`dirname $0`
 
 java -Xms16m -Xmx512m -Dibm.serversocket.recover=true -Dfile.encoding=UTF-8 \
-    -Djava.io.tmpdir=/tmp -Xquickstart  
-    -Dserver.port=**SERVER_PORT**   
-    -Dserver.ssl.keyAlias=**KEY_ALIAS**   
-    -Dserver.ssl.keyStore=**KEYSTORE**   
-    -Dserver.ssl.keyStorePassword=**KEYSTORE_PASSWORD**  
-    -Dserver.ssl.keyStoreType=PKCS12   
-    -Dzosmf.httpsPort=**ZOSMF_HTTPS_PORT**   
-    -Dzosmf.ipAddress=**ZOSMF_IP**
+    -Djava.io.tmpdir=/tmp -Xquickstart \
+    -Dserver.port=**SERVER_PORT** \
+    -Dserver.ssl.keyAlias=**KEY_ALIAS** \
+    -Dserver.ssl.keyStore=**KEYSTORE** \
+    -Dserver.ssl.keyStorePassword=**KEYSTORE_PASSWORD** \
+    -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dzosmf.httpsPort=**ZOSMF_HTTPS_PORT** \
+    -Dzosmf.ipAddress=**ZOSMF_IP** \
     -jar ../jobs-api-server-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
- Enabled integration test
- Package will be published to `libs-snapshot-local/org/zowe/explorer/jobs/jobs-zowe-server-package/0.0.1-SNAPSHOT/jobs-zowe-server-package-0.0.1-*.zip`. This package can be picked up by Zowe packaging for installation.

NOTE: there are 6 failed integration test cases.