### PR TITLE
incorrect substration

### DIFF
--- a/jobs-zowe-server-package/src/main/resources/scripts/jobs-api-validate.sh
+++ b/jobs-zowe-server-package/src/main/resources/scripts/jobs-api-validate.sh
@@ -44,4 +44,4 @@ fi
 
 . ${ROOT_DIR}/scripts/utils/validate-java.sh
 
-return $ERRORS_FOUND-$INITIAL_ERRORS_FOUND
+return $(($ERRORS_FOUND-$INITIAL_ERRORS_FOUND))


### PR DESCRIPTION
same like https://github.com/zowe/data-sets/pull/134
```
/root/zowe/1.7.0/components/jobs-api/bin/validate.sh: line 47: return: 2-2: numeric argument required
```