### PR TITLE
add gzip compression true by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,7 @@ node('ibm-jenkins-slave-nvm') {
 -Dserver.ssl.keyStore=localhost.keystore.p12 \
 -Dserver.ssl.keyStorePassword=password \
 -Dserver.ssl.keyStoreType=PKCS12 \
+-Dserver.compression.enabled=true \
 -Dzosmf.httpsPort=${params.INTEGRATION_TEST_ZOSMF_PORT} \
 -Dzosmf.ipAddress=${params.INTEGRATION_TEST_ZOSMF_HOST} \
 -jar \$(ls -1 jobs-api-server/build/libs/jobs-api-server-*-boot.jar) &"""

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
     -Dserver.ssl.keyStore=localhost.keystore.p12 \
     -Dserver.ssl.keyStorePassword=password \
     -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dserver.compression.enabled=true \
     -Dzosmf.httpsPort=${ZOSMF_PORT} \
     -Dzosmf.ipAddress=${ZOSMF_HOST} \
     -jar $(ls -1 jobs-api-server/build/libs/jobs-api-server-*.jar) &

--- a/jobs-api-server/src/main/java/org/zowe/jobs/spring/SwaggerConfig.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/spring/SwaggerConfig.java
@@ -9,10 +9,10 @@
  */
 package org.zowe.jobs.spring;
 
-import java.util.Collections;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
 
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -27,12 +27,12 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-        		.select()
-        		.apis(RequestHandlerSelectors.any())
+                .select()
+                .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.regex("/api.*"))
                 .build()
                 .apiInfo(
-                	new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "1.0", null, null, null, null, Collections.emptyList())
+                    new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "1.0", null, null, null, null, Collections.emptyList())
                 );
     }
 }

--- a/jobs-api-server/src/main/resources/application.yaml
+++ b/jobs-api-server/src/main/resources/application.yaml
@@ -36,6 +36,9 @@ server:
     keyAlias: ${server.ssl.keyAlias}
     enabled-protocols: TLSv1.2
     ciphers: ${apiml.security.ssl.ciphers}
+  compression:
+    enabled: ${server.compression.enabled}
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css
     
 zosmf:
   ipAddress: ${zosmf.ipAddress}

--- a/jobs-zowe-server-package/src/main/resources/scripts/jobs-api-start.sh
+++ b/jobs-zowe-server-package/src/main/resources/scripts/jobs-api-start.sh
@@ -28,6 +28,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${COMPONENT_CODE} java -Xms16m -Xmx512m -Dibm.servers
     -Dserver.ssl.keyStore=${KEYSTORE} \
     -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
     -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dserver.compression.enabled=true \
     -Dzosmf.httpsPort=${ZOSMF_PORT} \
     -Dzosmf.ipAddress=${ZOSMF_HOST} \
     -Dspring.main.banner-mode=off \


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

PR on same lines as datasets, to enable gzip compression before sending response to client
https://github.com/zowe/data-sets/pull/139

This is followup of issue: https://github.com/zowe/data-sets/issues/112
It also needs PR: https://github.com/zowe/api-layer/pull/463