### PR TITLE
upgrade springboot version

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
 
-    springBootVersion = '2.1.6.RELEASE'
+    springBootVersion = '2.1.7.RELEASE'
     springFoxVersion = '2.8.0'
     lombokVersion = '1.16.20'
     mockitoCoreVersion = '2.23.4'


### PR DESCRIPTION
Signed-off-by: Vit Tomica <vit.tomica@broadcom.com>

The current version of the springboot is causing problems when running the server on keyrings. Specifically, the tomcat-embed-core:9.0.21 package in the springboot is troublesome. The exception I get:
```
2020-03-03 10:38:37.563 <ZWEEAJ1:main:395650> TOMVI02 ERROR (o.a.t.u.n.SSLUtilBase,DirectJDKLog.java:175) Failed to load keystore type [JCERACFKS] with path [safkeyring://TOMVI02/ZOWE] due to [Array index out of range: 9830]
java.lang.ArrayIndexOutOfBoundsException: Array index out of range: 9830
	at java.lang.System.arraycopy(Native Method)
	at com.ibm.crypto.provider.RACFInputStream.read(Unknown Source)
	at com.ibm.crypto.provider.RACFInputStream.read(Unknown Source)
	at org.apache.tomcat.util.security.KeyStoreUtil.load(KeyStoreUtil.java:61)
	at org.apache.tomcat.util.net.SSLUtilBase.getStore(SSLUtilBase.java:217)
	at org.apache.tomcat.util.net.SSLHostConfigCertificate.getCertificateKeystore(SSLHostConfigCertificate.java:206)
	at org.apache.tomcat.util.net.SSLUtilBase.getKeyManagers(SSLUtilBase.java:280)
	at org.apache.tomcat.util.net.SSLUtilBase.createSSLContext(SSLUtilBase.java:247)
	at org.apache.tomcat.util.net.AbstractJsseEndpoint.createSSLContext(AbstractJsseEndpoint.java:97)
	at org.apache.tomcat.util.net.AbstractJsseEndpoint.initialiseSsl(AbstractJsseEndpoint.java:71)
	at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:218)
	at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1124)
	at org.apache.tomcat.util.net.AbstractEndpoint.start(AbstractEndpoint.java:1210)
	at org.apache.coyote.AbstractProtocol.start(AbstractProtocol.java:585)
	at org.apache.catalina.connector.Connector.startInternal(Connector.java:1005)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.StandardService.addConnector(StandardService.java:227)
	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.addPreviouslyRemovedConnectors(TomcatWebServer.java:263)
	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:195)
...
```

A newer version of the springboot that includes a newer version of the tomcat-embed-core package works fine with the keyrings.
