### PR TITLE
Implement passing ibm headers for jobs endpoints

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,7 +43,7 @@ ext {
 
         junit                              : "junit:junit:${junitVersion}",
 
-        explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:${explorerApiCommonVersion}",
+        explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:1.1.3-PR-67-20200728.133800-3",
         explorer_api_common_test           : "org.zowe.explorer.api:explorer-api-common-test:${explorerApiCommonVersion}"
     ]
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,7 +43,7 @@ ext {
 
         junit                              : "junit:junit:${junitVersion}",
 
-        explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:1.1.3-PR-67-20200728.133800-3",
+        explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:1.1.3-PR-67-20200728.154803-4",
         explorer_api_common_test           : "org.zowe.explorer.api:explorer-api-common-test:${explorerApiCommonVersion}"
     ]
 }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/JobsService.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/JobsService.java
@@ -23,20 +23,20 @@ public interface JobsService {
 
     ItemsWrapper<Job> getJobs(List<Header> headers, String prefix, String owner, JobStatus status) throws ZoweApiException;
 
-    Job getJob(String jobName, String jobId);
+    Job getJob(List<Header> headers, String jobName, String jobId);
 
-    void purgeJob(String jobName, String jobId);
+    void purgeJob(List<Header> headers, String jobName, String jobId);
     
-    void modifyJob(String jobName, String jobId, String command);
+    void modifyJob(List<Header> headers, String jobName, String jobId, String command);
 
-    Job submitJobString(String jclString);
+    Job submitJobString(List<Header> headers, String jclString);
 
-    Job submitJobFile(String file);
+    Job submitJobFile(List<Header> headers, String file);
 
-    ItemsWrapper<JobFile> getJobFiles(String jobName, String jobId);
+    ItemsWrapper<JobFile> getJobFiles(List<Header> headers, String jobName, String jobId);
 
-    JobFileContent getJobFileContent(String jobName, String jobId, String fileId);
+    JobFileContent getJobFileContent(List<Header> headers, String jobName, String jobId, String fileId);
 
-    JobFileContent getJobJcl(String jobName, String jobId);
+    JobFileContent getJobJcl(List<Header> headers, String jobName, String jobId);
 
 }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/JobsService.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/JobsService.java
@@ -9,6 +9,9 @@
  */
 package org.zowe.jobs.services;
 
+import java.util.List;
+
+import org.apache.http.Header;
 import org.zowe.api.common.exceptions.ZoweApiException;
 import org.zowe.api.common.model.ItemsWrapper;
 import org.zowe.jobs.model.Job;
@@ -18,7 +21,7 @@ import org.zowe.jobs.model.JobStatus;
 
 public interface JobsService {
 
-    ItemsWrapper<Job> getJobs(String prefix, String owner, JobStatus status) throws ZoweApiException;
+    ItemsWrapper<Job> getJobs(List<Header> headers, String prefix, String owner, JobStatus status) throws ZoweApiException;
 
     Job getJob(String jobName, String jobId);
 

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsRequestRunner.java
@@ -11,6 +11,9 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import java.util.List;
+
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.zowe.api.common.exceptions.ZoweApiRestException;
 import org.zowe.api.common.zosmf.services.AbstractZosmfRequestRunner;
@@ -20,6 +23,10 @@ import org.zowe.jobs.model.Job;
 import org.zowe.jobs.model.JobStatus;
 
 public abstract class AbstractZosmfJobsRequestRunner<T> extends AbstractZosmfRequestRunner<T> {
+
+    public AbstractZosmfJobsRequestRunner(List<Header> headers) {
+        super(headers);
+    }
 
     ZoweApiRestException createJobNotFoundExceptions(JsonObject jsonResponse, int statusCode, String jobName,
             String jobId) {

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsRequestRunner.java
@@ -11,6 +11,8 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 import org.apache.http.Header;
@@ -22,6 +24,7 @@ import org.zowe.jobs.exceptions.JobNameNotFoundException;
 import org.zowe.jobs.model.Job;
 import org.zowe.jobs.model.JobStatus;
 
+@NoArgsConstructor
 public abstract class AbstractZosmfJobsRequestRunner<T> extends AbstractZosmfRequestRunner<T> {
 
     public AbstractZosmfJobsRequestRunner(List<Header> headers) {

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsService.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsService.java
@@ -11,6 +11,9 @@ package org.zowe.jobs.services.zosmf;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
+import org.apache.http.Header;
 import org.zowe.api.common.connectors.zosmf.ZosmfConnector;
 import org.zowe.api.common.exceptions.ZoweApiException;
 import org.zowe.api.common.model.ItemsWrapper;
@@ -28,8 +31,8 @@ public abstract class AbstractZosmfJobsService implements JobsService {
     abstract ZosmfConnector getZosmfConnector();
 
     @Override
-    public ItemsWrapper<Job> getJobs(String prefix, String owner, JobStatus status) throws ZoweApiException {
-        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(prefix, owner, status);
+    public ItemsWrapper<Job> getJobs(List<Header> headers, String prefix, String owner, JobStatus status) throws ZoweApiException {
+        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(headers, prefix, owner, status);
         return runner.run(getZosmfConnector());
     }
 

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsService.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/AbstractZosmfJobsService.java
@@ -37,51 +37,51 @@ public abstract class AbstractZosmfJobsService implements JobsService {
     }
 
     @Override
-    public Job getJob(String jobName, String jobId) {
-        GetJobZosmfRequestRunner runner = new GetJobZosmfRequestRunner(jobName, jobId);
+    public Job getJob(List<Header> headers, String jobName, String jobId) {
+        GetJobZosmfRequestRunner runner = new GetJobZosmfRequestRunner(headers, jobName, jobId);
         return runner.run(getZosmfConnector());
     }
 
     @Override
-    public Job submitJobString(String jcl) {
-        SubmitJobStringZosmfRequestRunner runner = new SubmitJobStringZosmfRequestRunner(jcl);
+    public Job submitJobString(List<Header> headers, String jcl) {
+        SubmitJobStringZosmfRequestRunner runner = new SubmitJobStringZosmfRequestRunner(headers, jcl);
         return runner.run(getZosmfConnector());
     }
 
     @Override
-    public Job submitJobFile(String fileName) {
-        SubmitJobFileZosmfRequestRunner runner = new SubmitJobFileZosmfRequestRunner(fileName);
+    public Job submitJobFile(List<Header> headers, String fileName) {
+        SubmitJobFileZosmfRequestRunner runner = new SubmitJobFileZosmfRequestRunner(headers, fileName);
         return runner.run(getZosmfConnector());
     }
 
     @Override
-    public void purgeJob(String jobName, String jobId) {
-        PurgeJobZosmfRequestRunner runner = new PurgeJobZosmfRequestRunner(jobName, jobId);
+    public void purgeJob(List<Header> headers, String jobName, String jobId) {
+        PurgeJobZosmfRequestRunner runner = new PurgeJobZosmfRequestRunner(headers, jobName, jobId);
         runner.run(getZosmfConnector());
     }
     
     @Override
-    public void modifyJob(String jobName, String jobId, String command) {
-        ModifyJobZosmfRequestRunner runner = new ModifyJobZosmfRequestRunner(jobName, jobId, command);
+    public void modifyJob(List<Header> headers, String jobName, String jobId, String command) {
+        ModifyJobZosmfRequestRunner runner = new ModifyJobZosmfRequestRunner(headers, jobName, jobId, command);
         runner.run(getZosmfConnector());
     }
 
     @Override
-    public ItemsWrapper<JobFile> getJobFiles(String jobName, String jobId) {
-        GetJobFilesZosmfRequestRunner runner = new GetJobFilesZosmfRequestRunner(jobName, jobId);
+    public ItemsWrapper<JobFile> getJobFiles(List<Header> headers, String jobName, String jobId) {
+        GetJobFilesZosmfRequestRunner runner = new GetJobFilesZosmfRequestRunner(headers, jobName, jobId);
         return runner.run(getZosmfConnector());
     }
 
     @Override
-    public JobFileContent getJobFileContent(String jobName, String jobId, String fileId) {
-        GetJobFileContentZosmfRequestRunner runner = new GetJobFileContentZosmfRequestRunner(jobName, jobId, fileId);
+    public JobFileContent getJobFileContent(List<Header> headers, String jobName, String jobId, String fileId) {
+        GetJobFileContentZosmfRequestRunner runner = new GetJobFileContentZosmfRequestRunner(headers, jobName, jobId, fileId);
         return runner.run(getZosmfConnector());
     }
 
     @Override
-    public JobFileContent getJobJcl(String jobName, String jobId) {
+    public JobFileContent getJobJcl(List<Header> headers, String jobName, String jobId) {
         try {
-            return getJobFileContent(jobName, jobId, "3");
+            return getJobFileContent(headers, jobName, jobId, "3");
         } catch (JobFileIdNotFoundException e) {
             log.error("getJobJcl", e);
             throw new JobJesjclNotFoundException(jobName, jobId);

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFileContentZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFileContentZosmfRequestRunner.java
@@ -30,6 +30,7 @@ public class GetJobFileContentZosmfRequestRunner extends AbstractZosmfJobsReques
     private String fileId;
 
     public GetJobFileContentZosmfRequestRunner(String jobName, String jobId, String fileId) {
+        super(null);
         this.jobName = jobName;
         this.jobId = jobId;
         this.fileId = fileId;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFileContentZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFileContentZosmfRequestRunner.java
@@ -11,6 +11,7 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.zowe.api.common.connectors.zosmf.ZosmfConnector;
@@ -22,6 +23,7 @@ import org.zowe.jobs.model.JobFileContent;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 public class GetJobFileContentZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<JobFileContent> {
 
@@ -29,8 +31,8 @@ public class GetJobFileContentZosmfRequestRunner extends AbstractZosmfJobsReques
     private String jobId;
     private String fileId;
 
-    public GetJobFileContentZosmfRequestRunner(String jobName, String jobId, String fileId) {
-        super(null);
+    public GetJobFileContentZosmfRequestRunner(List<Header> headers, String jobName, String jobId, String fileId) {
+        super(headers);
         this.jobName = jobName;
         this.jobId = jobId;
         this.fileId = fileId;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFilesZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFilesZosmfRequestRunner.java
@@ -32,6 +32,7 @@ public class GetJobFilesZosmfRequestRunner extends AbstractZosmfJobsRequestRunne
     private String jobId;
 
     public GetJobFilesZosmfRequestRunner(String jobName, String jobId) {
+        super(null);
         this.jobName = jobName;
         this.jobId = jobId;
     }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFilesZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobFilesZosmfRequestRunner.java
@@ -12,6 +12,7 @@ package org.zowe.jobs.services.zosmf;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.zowe.api.common.connectors.zosmf.ZosmfConnector;
@@ -31,8 +32,8 @@ public class GetJobFilesZosmfRequestRunner extends AbstractZosmfJobsRequestRunne
     private String jobName;
     private String jobId;
 
-    public GetJobFilesZosmfRequestRunner(String jobName, String jobId) {
-        super(null);
+    public GetJobFilesZosmfRequestRunner(List<Header> headers, String jobName, String jobId) {
+        super(headers);
         this.jobName = jobName;
         this.jobId = jobId;
     }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobZosmfRequestRunner.java
@@ -11,6 +11,7 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.zowe.api.common.connectors.zosmf.ZosmfConnector;
@@ -21,14 +22,15 @@ import org.zowe.jobs.model.Job;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 public class GetJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<Job> {
 
     private String jobName;
     private String jobId;
 
-    public GetJobZosmfRequestRunner(String jobName, String jobId) {
-        super(null);
+    public GetJobZosmfRequestRunner(List<Header> headers, String jobName, String jobId) {
+        super(headers);
         this.jobName = jobName;
         this.jobId = jobId;
     }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobZosmfRequestRunner.java
@@ -28,6 +28,7 @@ public class GetJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<Job
     private String jobId;
 
     public GetJobZosmfRequestRunner(String jobName, String jobId) {
+        super(null);
         this.jobName = jobName;
         this.jobId = jobId;
     }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobsZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/GetJobsZosmfRequestRunner.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonObject;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.zowe.api.common.connectors.zosmf.ZosmfConnector;
@@ -38,7 +39,8 @@ public class GetJobsZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<It
     private String prefix;
     private String owner;
 
-    public GetJobsZosmfRequestRunner(String prefix, String owner, JobStatus status) {
+    public GetJobsZosmfRequestRunner(List<Header> headers, String prefix, String owner, JobStatus status) {
+        super(headers);
         this.status = status;
         this.prefix = prefix;
         this.owner = owner;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/ModifyJobZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/ModifyJobZosmfRequestRunner.java
@@ -30,6 +30,7 @@ public class ModifyJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<
     private String command;
 
     public ModifyJobZosmfRequestRunner(String jobName, String jobId, String command) {
+        super(null);
         this.jobName = jobName;
         this.jobId = jobId;
         this.command = command;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/ModifyJobZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/ModifyJobZosmfRequestRunner.java
@@ -11,6 +11,7 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -22,6 +23,7 @@ import org.zowe.api.common.utils.ResponseCache;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 public class ModifyJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<Void> {
 
@@ -29,8 +31,8 @@ public class ModifyJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<
     private String jobId;
     private String command;
 
-    public ModifyJobZosmfRequestRunner(String jobName, String jobId, String command) {
-        super(null);
+    public ModifyJobZosmfRequestRunner(List<Header> headers, String jobName, String jobId, String command) {
+        super(headers);
         this.jobName = jobName;
         this.jobId = jobId;
         this.command = command;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/PurgeJobZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/PurgeJobZosmfRequestRunner.java
@@ -27,6 +27,7 @@ public class PurgeJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<V
     private String jobId;
 
     public PurgeJobZosmfRequestRunner(String jobName, String jobId) {
+        super(null);
         this.jobName = jobName;
         this.jobId = jobId;
     }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/PurgeJobZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/PurgeJobZosmfRequestRunner.java
@@ -11,6 +11,7 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.zowe.api.common.connectors.zosmf.ZosmfConnector;
@@ -20,14 +21,15 @@ import org.zowe.api.common.utils.ResponseCache;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 public class PurgeJobZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<Void> {
 
     private String jobName;
     private String jobId;
 
-    public PurgeJobZosmfRequestRunner(String jobName, String jobId) {
-        super(null);
+    public PurgeJobZosmfRequestRunner(List<Header> headers, String jobName, String jobId) {
+        super(headers);
         this.jobName = jobName;
         this.jobId = jobId;
     }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobFileZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobFileZosmfRequestRunner.java
@@ -11,6 +11,7 @@ package org.zowe.jobs.services.zosmf;
 
 import com.google.gson.JsonObject;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -24,13 +25,14 @@ import org.zowe.jobs.model.Job;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 public class SubmitJobFileZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<Job> {
 
     private String fileName;
 
-    public SubmitJobFileZosmfRequestRunner(String fileName) {
-        super(null);
+    public SubmitJobFileZosmfRequestRunner(List<Header> headers, String fileName) {
+        super(headers);
         this.fileName = fileName;
     }
 

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobFileZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobFileZosmfRequestRunner.java
@@ -30,6 +30,7 @@ public class SubmitJobFileZosmfRequestRunner extends AbstractZosmfJobsRequestRun
     private String fileName;
 
     public SubmitJobFileZosmfRequestRunner(String fileName) {
+        super(null);
         this.fileName = fileName;
     }
 

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobStringZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobStringZosmfRequestRunner.java
@@ -9,6 +9,7 @@
  */
 package org.zowe.jobs.services.zosmf;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -20,13 +21,14 @@ import org.zowe.jobs.model.Job;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 public class SubmitJobStringZosmfRequestRunner extends AbstractZosmfJobsRequestRunner<Job> {
 
     private String jcl;
 
-    public SubmitJobStringZosmfRequestRunner(String jcl) {
-        super(null);
+    public SubmitJobStringZosmfRequestRunner(List<Header> headers, String jcl) {
+        super(headers);
         this.jcl = jcl;
     }
 

--- a/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobStringZosmfRequestRunner.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/services/zosmf/SubmitJobStringZosmfRequestRunner.java
@@ -26,6 +26,7 @@ public class SubmitJobStringZosmfRequestRunner extends AbstractZosmfJobsRequestR
     private String jcl;
 
     public SubmitJobStringZosmfRequestRunner(String jcl) {
+        super(null);
         this.jcl = jcl;
     }
 

--- a/jobs-api-server/src/test/java/org/zowe/jobs/controller/JobsControllerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/controller/JobsControllerTest.java
@@ -90,13 +90,13 @@ public class JobsControllerTest extends ApiControllerTest {
         List<Job> jobs = Arrays.asList(dummyJob, dummyJob2);
         ItemsWrapper<Job> items = new ItemsWrapper<Job>(jobs);
 
-        when(jobsService.getJobs("TESTNAME", "*", JobStatus.ALL)).thenReturn(items);
+        when(jobsService.getJobs(null, "TESTNAME", "*", JobStatus.ALL)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}&owner={owner}", "TESTNAME", "*"))
             .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
-        verify(jobsService, times(1)).getJobs("TESTNAME", "*", JobStatus.ALL);
+        verify(jobsService, times(1)).getJobs(null, "TESTNAME", "*", JobStatus.ALL);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -108,7 +108,7 @@ public class JobsControllerTest extends ApiControllerTest {
         List<Job> jobs = Arrays.asList(dummyJob, dummyJob2);
         ItemsWrapper<Job> items = new ItemsWrapper<Job>(jobs);
 
-        when(jobsService.getJobs("TESTNAME", "*", JobStatus.ACTIVE)).thenReturn(items);
+        when(jobsService.getJobs(null, "TESTNAME", "*", JobStatus.ACTIVE)).thenReturn(items);
 
         mockMvc
             .perform(get(ENDPOINT_ROOT + "?prefix={prefix}&owner={owner}&status={status}", "TESTNAME", "*",
@@ -116,7 +116,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
-        verify(jobsService, times(1)).getJobs("TESTNAME", "*", JobStatus.ACTIVE);
+        verify(jobsService, times(1)).getJobs(null, "TESTNAME", "*", JobStatus.ACTIVE);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -128,13 +128,13 @@ public class JobsControllerTest extends ApiControllerTest {
         List<Job> jobs = Arrays.asList(dummyJob, dummyJob2);
         ItemsWrapper<Job> items = new ItemsWrapper<Job>(jobs);
 
-        when(jobsService.getJobs("TESTNAME", null, JobStatus.ALL)).thenReturn(items);
+        when(jobsService.getJobs(null, "TESTNAME", null, JobStatus.ALL)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}", "TESTNAME")).andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
-        verify(jobsService, times(1)).getJobs("TESTNAME", null, JobStatus.ALL);
+        verify(jobsService, times(1)).getJobs(null, "TESTNAME", null, JobStatus.ALL);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -143,13 +143,13 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ItemsWrapper<Job> items = new ItemsWrapper<Job>(Collections.emptyList());
 
-        when(jobsService.getJobs("TESTNAME", null, JobStatus.ALL)).thenReturn(items);
+        when(jobsService.getJobs(null, "TESTNAME", null, JobStatus.ALL)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}", "TESTNAME")).andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(EMPTY_ITEMS));
 
-        verify(jobsService, times(1)).getJobs("TESTNAME", null, JobStatus.ALL);
+        verify(jobsService, times(1)).getJobs(null, "TESTNAME", null, JobStatus.ALL);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -162,13 +162,13 @@ public class JobsControllerTest extends ApiControllerTest {
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.BAD_REQUEST).build();
 
         InvalidOwnerException zoweException = new InvalidOwnerException(invalidOwner);
-        when(jobsService.getJobs("TESTNAME", invalidOwner, JobStatus.ALL)).thenThrow(zoweException);
+        when(jobsService.getJobs(null, "TESTNAME", invalidOwner, JobStatus.ALL)).thenThrow(zoweException);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}&owner={owner}", "TESTNAME", invalidOwner))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).getJobs("TESTNAME", invalidOwner, JobStatus.ALL);
+        verify(jobsService, times(1)).getJobs(null, "TESTNAME", invalidOwner, JobStatus.ALL);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -177,13 +177,13 @@ public class JobsControllerTest extends ApiControllerTest {
         // TODO - tidy up constants
         Job dummyJob = Job.builder().jobId("TESTID11").jobName("TESTNAME").status(JobStatus.ACTIVE).build();
 
-        when(jobsService.getJob("TESTNAME", "TESTID11")).thenReturn(dummyJob);
+        when(jobsService.getJob(null, "TESTNAME", "TESTID11")).thenReturn(dummyJob);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}", "TESTNAME", "TESTID11")).andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)));
 
-        verify(jobsService, times(1)).getJob("TESTNAME", "TESTID11");
+        verify(jobsService, times(1)).getJob(null, "TESTNAME", "TESTID11");
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -197,14 +197,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJob(jobName, jobId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJob(null, jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/", jobName, jobId)).andExpect(status().isIAmATeapot())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).getJob(jobName, jobId);
+        verify(jobsService, times(1)).getJob(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -216,14 +216,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJob(jobName, jobId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJob(null, jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/", jobName, jobId)).andExpect(status().isIAmATeapot())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).getJob(jobName, jobId);
+        verify(jobsService, times(1)).getJob(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -239,13 +239,13 @@ public class JobsControllerTest extends ApiControllerTest {
 
         String jobName = "TESTNAME";
         String jobId = "TESTID11";
-        when(jobsService.getJobFiles(jobName, jobId)).thenReturn(items);
+        when(jobsService.getJobFiles(null, jobName, jobId)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files", jobName, jobId)).andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
-        verify(jobsService, times(1)).getJobFiles(jobName, jobId);
+        verify(jobsService, times(1)).getJobFiles(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -259,14 +259,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJobFiles(jobName, jobId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJobFiles(null, jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files", jobName, jobId))
             .andExpect(status().isIAmATeapot()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).getJobFiles(jobName, jobId);
+        verify(jobsService, times(1)).getJobFiles(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -279,13 +279,13 @@ public class JobsControllerTest extends ApiControllerTest {
         String jobName = "TESTNAME";
         String jobId = "TESTID11";
         String fileId = "3";
-        when(jobsService.getJobFileContent(jobName, jobId, fileId)).thenReturn(jobFileContent);
+        when(jobsService.getJobFileContent(null, jobName, jobId, fileId)).thenReturn(jobFileContent);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/{fileId}/content", jobName, jobId, fileId))
             .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(jobFileContent)));
 
-        verify(jobsService, times(1)).getJobFileContent(jobName, jobId, fileId);
+        verify(jobsService, times(1)).getJobFileContent(null, jobName, jobId, fileId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -300,14 +300,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJobFileContent(jobName, jobId, fileId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJobFileContent(null, jobName, jobId, fileId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/{fileId}/content", jobName, jobId, fileId))
             .andExpect(status().isIAmATeapot()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).getJobFileContent(jobName, jobId, fileId);
+        verify(jobsService, times(1)).getJobFileContent(null, jobName, jobId, fileId);
         verifyNoMoreInteractions(jobsService);
     }
     
@@ -322,7 +322,7 @@ public class JobsControllerTest extends ApiControllerTest {
         
         String jobId = "jobId";
         String jobName = "jobName";
-        when(jobsService.getJobFiles(jobName, jobId)).thenReturn(items);
+        when(jobsService.getJobFiles(null, jobName, jobId)).thenReturn(items);
         
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files", jobName, jobId)).andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
@@ -333,8 +333,8 @@ public class JobsControllerTest extends ApiControllerTest {
         
         String fileId1 = "3";
         String fileId2 = "2";
-        when(jobsService.getJobFileContent(jobName, jobId, fileId1)).thenReturn(jobFileContent1);
-        when(jobsService.getJobFileContent(jobName, jobId, fileId2)).thenReturn(jobFileContent2);
+        when(jobsService.getJobFileContent(null, jobName, jobId, fileId1)).thenReturn(jobFileContent1);
+        when(jobsService.getJobFileContent(null, jobName, jobId, fileId2)).thenReturn(jobFileContent2);
         
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/{fileId}/content", jobName, jobId, fileId1))
         .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
@@ -361,14 +361,14 @@ public class JobsControllerTest extends ApiControllerTest {
         String jobName = "TESTNAME";
         String jobId = "TESTID11";
 
-        when(jobsService.getJobJcl(jobName, jobId))
+        when(jobsService.getJobJcl(null, jobName, jobId))
             .thenReturn(new JobFileContent(loadFile("src/test/resources/testData/JESJCL")));
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/steps", jobName, jobId)).andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(expected)));
 
-        verify(jobsService, times(1)).getJobJcl(jobName, jobId);
+        verify(jobsService, times(1)).getJobJcl(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -382,14 +382,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJobJcl(jobName, jobId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJobJcl(null, jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/steps", jobName, jobId))
             .andExpect(status().isIAmATeapot()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).getJobJcl(jobName, jobId);
+        verify(jobsService, times(1)).getJobJcl(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -403,14 +403,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = expectedException.getApiError();
 
-        doThrow(new JobJesjclNotFoundException(jobName, jobId)).when(jobsService).getJobJcl(jobName, jobId);
+        doThrow(new JobJesjclNotFoundException(jobName, jobId)).when(jobsService).getJobJcl(null, jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/steps", jobName, jobId))
             .andExpect(status().isIAmATeapot()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(expectedError.getMessage()));
 
-        verify(jobsService, times(1)).getJobJcl(jobName, jobId);
+        verify(jobsService, times(1)).getJobJcl(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -422,7 +422,7 @@ public class JobsControllerTest extends ApiControllerTest {
         mockMvc.perform(delete(ENDPOINT_ROOT + "/{jobName}/{jobId}/", jobName, jobId)).andExpect(status().isNoContent())
             .andExpect(jsonPath("$").doesNotExist());
 
-        verify(jobsService, times(1)).purgeJob(jobName, jobId);
+        verify(jobsService, times(1)).purgeJob(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -435,13 +435,13 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).purgeJob(jobName, jobId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).purgeJob(null, jobName, jobId);
 
         mockMvc.perform(delete(ENDPOINT_ROOT + "/{jobName}/{jobId}/", jobName, jobId))
             .andExpect(status().isIAmATeapot()).andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).purgeJob(jobName, jobId);
+        verify(jobsService, times(1)).purgeJob(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
     
@@ -457,7 +457,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .content(JsonUtils.convertToJsonString(request))).andExpect(status().isNoContent())
             .andExpect(jsonPath("$").doesNotExist());
 
-        verify(jobsService, times(2)).purgeJob(jobName, jobId);
+        verify(jobsService, times(2)).purgeJob(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
     
@@ -472,14 +472,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).purgeJob(jobName, jobId);
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).purgeJob(null, jobName, jobId);
 
         mockMvc.perform(delete(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
             .content(JsonUtils.convertToJsonString(request)))
             .andExpect(status().isIAmATeapot()).andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).purgeJob(jobName, jobId);
+        verify(jobsService, times(1)).purgeJob(null, jobName, jobId);
         verifyNoMoreInteractions(jobsService);
     }
     
@@ -494,7 +494,7 @@ public class JobsControllerTest extends ApiControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE).content(JsonUtils.convertToJsonString(request)))
                 .andExpect(status().isAccepted());
         
-        verify(jobsService, times(1)).modifyJob(jobName, jobId, request.getCommand());
+        verify(jobsService, times(1)).modifyJob(null, jobName, jobId, request.getCommand());
         verifyNoMoreInteractions(jobsService);
     }
     
@@ -509,14 +509,14 @@ public class JobsControllerTest extends ApiControllerTest {
 
         ModifyJobRequest request = new ModifyJobRequest("cancel");
         
-        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).modifyJob(jobName, jobId, request.getCommand());
+        doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).modifyJob(null, jobName, jobId, request.getCommand());
         
         mockMvc.perform(put(ENDPOINT_ROOT + "/{jobName}/{jobId}", jobName, jobId)
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE).content(JsonUtils.convertToJsonString(request)))
             .andExpect(status().isNotFound()).andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
         
-        verify(jobsService, times(1)).modifyJob(jobName, jobId, request.getCommand());
+        verify(jobsService, times(1)).modifyJob(null, jobName, jobId, request.getCommand());
         verifyNoMoreInteractions(jobsService);
     }
     
@@ -534,7 +534,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .content(JsonUtils.convertToJsonString(modifyRequest)))
             .andExpect(status().isAccepted()).andExpect(jsonPath("$").doesNotExist());
 
-        verify(jobsService, times(2)).modifyJob(jobName, jobId, modifyCommand);
+        verify(jobsService, times(2)).modifyJob(null, jobName, jobId, modifyCommand);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -549,7 +549,7 @@ public class JobsControllerTest extends ApiControllerTest {
                 + "//UNIT     EXEC PGM=IEFBR14";
         SubmitJobStringRequest request = new SubmitJobStringRequest(dummyJcl);
 
-        when(jobsService.submitJobString(dummyJcl)).thenReturn(dummyJob);
+        when(jobsService.submitJobString(null, dummyJcl)).thenReturn(dummyJob);
 
         URI locationUri = new URI("https://jobURI/jobs/" + jobName + "/" + jobId);
         mockJobUriConstruction(jobName, jobId, locationUri);
@@ -561,7 +561,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)))
             .andExpect(header().string("Location", locationUri.toString()));
 
-        verify(jobsService, times(1)).submitJobString(dummyJcl);
+        verify(jobsService, times(1)).submitJobString(null, dummyJcl);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -589,7 +589,7 @@ public class JobsControllerTest extends ApiControllerTest {
         String errorMessage = "Some nonsense about submit failing";
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        when(jobsService.submitJobString(dummyJcl)).thenThrow(new ZoweApiErrorException(expectedError));
+        when(jobsService.submitJobString(null, dummyJcl)).thenThrow(new ZoweApiErrorException(expectedError));
 
         mockMvc
             .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -597,7 +597,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).submitJobString(dummyJcl);
+        verify(jobsService, times(1)).submitJobString(null, dummyJcl);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -610,7 +610,7 @@ public class JobsControllerTest extends ApiControllerTest {
         String dummyDataSet = "STEVENH.TEST.JCL(IEFBR14)";
         SubmitJobFileRequest request = new SubmitJobFileRequest(dummyDataSet);
 
-        when(jobsService.submitJobFile(dummyDataSet)).thenReturn(dummyJob);
+        when(jobsService.submitJobFile(null, dummyDataSet)).thenReturn(dummyJob);
         URI locationUri = new URI("https://jobURI/jobs/" + jobName + "/" + jobId);
         mockJobUriConstruction(jobName, jobId, locationUri);
 
@@ -621,7 +621,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)))
             .andExpect(header().string("Location", locationUri.toString()));
 
-        verify(jobsService, times(1)).submitJobFile(dummyDataSet);
+        verify(jobsService, times(1)).submitJobFile(null, dummyDataSet);
         verifyNoMoreInteractions(jobsService);
     }
 
@@ -632,7 +632,7 @@ public class JobsControllerTest extends ApiControllerTest {
         String errorMessage = "Some nonsense about submit failing";
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.I_AM_A_TEAPOT).build();
 
-        when(jobsService.submitJobFile(dummyDataSet)).thenThrow(new ZoweApiErrorException(expectedError));
+        when(jobsService.submitJobFile(null, dummyDataSet)).thenThrow(new ZoweApiErrorException(expectedError));
 
         mockMvc
             .perform(post(ENDPOINT_ROOT + "/dataset").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -640,7 +640,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
-        verify(jobsService, times(1)).submitJobFile(dummyDataSet);
+        verify(jobsService, times(1)).submitJobFile(null, dummyDataSet);
         verifyNoMoreInteractions(jobsService);
     }
 

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobFileContentZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobFileContentZosmfRequestRunnerTest.java
@@ -42,7 +42,7 @@ public class GetJobFileContentZosmfRequestRunnerTest extends AbstractZosmfReques
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobFileContentZosmfRequestRunner runner = new GetJobFileContentZosmfRequestRunner(jobName, jobId, fileId);
+        GetJobFileContentZosmfRequestRunner runner = new GetJobFileContentZosmfRequestRunner(null, jobName, jobId, fileId);
 
         assertEquals(expected, runner.run(zosmfConnector));
 
@@ -94,7 +94,7 @@ public class GetJobFileContentZosmfRequestRunnerTest extends AbstractZosmfReques
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobFileContentZosmfRequestRunner runner = new GetJobFileContentZosmfRequestRunner(jobName, jobId, fileId);
+        GetJobFileContentZosmfRequestRunner runner = new GetJobFileContentZosmfRequestRunner(null, jobName, jobId, fileId);
         shouldThrow(expectedException, () -> runner.run(zosmfConnector));
         verifyInteractions(requestBuilder);
     }

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobFilesZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobFilesZosmfRequestRunnerTest.java
@@ -46,7 +46,7 @@ public class GetJobFilesZosmfRequestRunnerTest extends AbstractZosmfRequestRunne
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobFilesZosmfRequestRunner runner = new GetJobFilesZosmfRequestRunner(jobName, jobId);
+        GetJobFilesZosmfRequestRunner runner = new GetJobFilesZosmfRequestRunner(null, jobName, jobId);
         assertEquals(expected, runner.run(zosmfConnector));
 
         verifyInteractions(requestBuilder);
@@ -82,7 +82,7 @@ public class GetJobFilesZosmfRequestRunnerTest extends AbstractZosmfRequestRunne
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobFilesZosmfRequestRunner runner = new GetJobFilesZosmfRequestRunner(jobName, jobId);
+        GetJobFilesZosmfRequestRunner runner = new GetJobFilesZosmfRequestRunner(null, jobName, jobId);
         shouldThrow(expectedException, () -> runner.run(zosmfConnector));
         verifyInteractions(requestBuilder);
     }

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobZosmfRequestRunnerTest.java
@@ -38,7 +38,7 @@ public class GetJobZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunner
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobZosmfRequestRunner runner = new GetJobZosmfRequestRunner(jobName, jobId);
+        GetJobZosmfRequestRunner runner = new GetJobZosmfRequestRunner(null, jobName, jobId);
         assertEquals(expected, runner.run(zosmfConnector));
 
         verifyInteractions(requestBuilder);
@@ -74,7 +74,7 @@ public class GetJobZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunner
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobZosmfRequestRunner runner = new GetJobZosmfRequestRunner(jobName, jobId);
+        GetJobZosmfRequestRunner runner = new GetJobZosmfRequestRunner(null, jobName, jobId);
         shouldThrow(expectedException, () -> runner.run(zosmfConnector));
         verifyInteractions(requestBuilder);
     }

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobsZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/GetJobsZosmfRequestRunnerTest.java
@@ -64,7 +64,7 @@ public class GetJobsZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunne
         RequestBuilder requestBuilder = mockGetBuilder("restjobs/jobs?prefix=*");
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner("*", null, JobStatus.OUTPUT);
+        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(null, "*", null, JobStatus.OUTPUT);
         assertEquals(new ItemsWrapper<>(Arrays.asList(job1, job4)), runner.run(zosmfConnector));
 
         verifyInteractions(requestBuilder, true);
@@ -79,7 +79,7 @@ public class GetJobsZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunne
                 String.format("restjobs/jobs?owner=%s&prefix=%s", owner, prefix));
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(prefix, owner, status);
+        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(null, prefix, owner, status);
         assertEquals(new ItemsWrapper<>(expected), runner.run(zosmfConnector));
 
         verifyInteractions(requestBuilder, true);
@@ -130,7 +130,7 @@ public class GetJobsZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunne
         RequestBuilder requestBuilder = mockGetBuilder(path);
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(prefix, owner, JobStatus.ALL);
+        GetJobsZosmfRequestRunner runner = new GetJobsZosmfRequestRunner(null, prefix, owner, JobStatus.ALL);
         shouldThrow(expectedException, () -> runner.run(zosmfConnector));
 
         verifyInteractions(requestBuilder, true);

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/ModifyJobZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/ModifyJobZosmfRequestRunnerTest.java
@@ -37,7 +37,7 @@ public class ModifyJobZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRun
                 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
         
-        new ModifyJobZosmfRequestRunner(jobName, jobId, command).run(zosmfConnector);
+        new ModifyJobZosmfRequestRunner(null, jobName, jobId, command).run(zosmfConnector);
         
         verifyInteractions(requestBuilder);
     }
@@ -58,7 +58,7 @@ public class ModifyJobZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRun
         
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
         
-        shouldThrow(expectedException, () -> new ModifyJobZosmfRequestRunner(jobName, jobId, command).run(zosmfConnector));
+        shouldThrow(expectedException, () -> new ModifyJobZosmfRequestRunner(null, jobName, jobId, command).run(zosmfConnector));
         
         verifyInteractions(requestBuilder);
     }

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/PurgeJobZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/PurgeJobZosmfRequestRunnerTest.java
@@ -29,7 +29,7 @@ public class PurgeJobZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunn
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        new PurgeJobZosmfRequestRunner(jobName, jobId).run(zosmfConnector);
+        new PurgeJobZosmfRequestRunner(null, jobName, jobId).run(zosmfConnector);
 
         verifyInteractions(requestBuilder);
     }
@@ -47,7 +47,7 @@ public class PurgeJobZosmfRequestRunnerTest extends AbstractZosmfJobsRequestRunn
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        shouldThrow(expectedException, () -> new PurgeJobZosmfRequestRunner(jobName, jobId).run(zosmfConnector));
+        shouldThrow(expectedException, () -> new PurgeJobZosmfRequestRunner(null, jobName, jobId).run(zosmfConnector));
         verifyInteractions(requestBuilder);
     }
 

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/SubmitJobFileZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/SubmitJobFileZosmfRequestRunnerTest.java
@@ -43,7 +43,7 @@ public class SubmitJobFileZosmfRequestRunnerTest extends AbstractZosmfJobsReques
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        assertEquals(expected, new SubmitJobFileZosmfRequestRunner(dataSet).run(zosmfConnector));
+        assertEquals(expected, new SubmitJobFileZosmfRequestRunner(null, dataSet).run(zosmfConnector));
 
         verifyInteractions(requestBuilder);
     }
@@ -76,7 +76,7 @@ public class SubmitJobFileZosmfRequestRunnerTest extends AbstractZosmfJobsReques
         RequestBuilder requestBuilder = mockPutBuilder("restjobs/jobs", body);
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        shouldThrow(expectedException, () -> new SubmitJobFileZosmfRequestRunner(fileName).run(zosmfConnector));
+        shouldThrow(expectedException, () -> new SubmitJobFileZosmfRequestRunner(null, fileName).run(zosmfConnector));
         verifyInteractions(requestBuilder);
     }
 

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/SubmitJobStringZosmfRequestRunnerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/SubmitJobStringZosmfRequestRunnerTest.java
@@ -41,7 +41,7 @@ public class SubmitJobStringZosmfRequestRunnerTest extends AbstractZosmfJobsRequ
 
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        assertEquals(expected, new SubmitJobStringZosmfRequestRunner(jclString).run(zosmfConnector));
+        assertEquals(expected, new SubmitJobStringZosmfRequestRunner(null, jclString).run(zosmfConnector));
 
         verifyInteractions(requestBuilder);
         verify(requestBuilder).addHeader("Content-type", ContentType.TEXT_PLAIN.getMimeType());
@@ -84,7 +84,7 @@ public class SubmitJobStringZosmfRequestRunnerTest extends AbstractZosmfJobsRequ
         RequestBuilder requestBuilder = mockPutBuilder("restjobs/jobs", badJcl);
         when(zosmfConnector.executeRequest(requestBuilder)).thenReturn(response);
 
-        shouldThrow(expectedException, () -> new SubmitJobStringZosmfRequestRunner(badJcl).run(zosmfConnector));
+        shouldThrow(expectedException, () -> new SubmitJobStringZosmfRequestRunner(null, badJcl).run(zosmfConnector));
         verifyInteractions(requestBuilder);
     }
 

--- a/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/ZosmfJobsServiceTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/services/zosmf/ZosmfJobsServiceTest.java
@@ -70,7 +70,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         GetJobsZosmfRequestRunner runner = mock(GetJobsZosmfRequestRunner.class);
         when(runner.run(zosmfConnector)).thenReturn(expected);
         PowerMockito.whenNew(GetJobsZosmfRequestRunner.class).withArguments(prefix, owner, status).thenReturn(runner);
-        assertEquals(expected, jobsService.getJobs(prefix, owner, status));
+        assertEquals(expected, jobsService.getJobs(null, prefix, owner, status));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(GetJobsZosmfRequestRunner.class).withArguments(prefix, owner, status).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.getJobs(prefix, owner, status));
+        shouldThrow(expectedException, () -> jobsService.getJobs(null, prefix, owner, status));
     }
 
     @Test
@@ -98,7 +98,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         GetJobZosmfRequestRunner runner = mock(GetJobZosmfRequestRunner.class);
         when(runner.run(zosmfConnector)).thenReturn(expected);
         PowerMockito.whenNew(GetJobZosmfRequestRunner.class).withArguments(jobName, jobId).thenReturn(runner);
-        assertEquals(expected, jobsService.getJob(jobName, jobId));
+        assertEquals(expected, jobsService.getJob(null, jobName, jobId));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(GetJobZosmfRequestRunner.class).withArguments(jobName, jobId).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.getJob(jobName, jobId));
+        shouldThrow(expectedException, () -> jobsService.getJob(null, jobName, jobId));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenReturn(expected);
         PowerMockito.whenNew(SubmitJobStringZosmfRequestRunner.class).withArguments(jcl).thenReturn(runner);
 
-        assertEquals(expected, jobsService.submitJobString(jcl));
+        assertEquals(expected, jobsService.submitJobString(null, jcl));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(SubmitJobStringZosmfRequestRunner.class).withArguments(jcl).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.submitJobString(jcl));
+        shouldThrow(expectedException, () -> jobsService.submitJobString(null, jcl));
     }
 
     @Test
@@ -152,7 +152,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenReturn(expected);
         PowerMockito.whenNew(SubmitJobFileZosmfRequestRunner.class).withArguments(fileName).thenReturn(runner);
 
-        assertEquals(expected, jobsService.submitJobFile(fileName));
+        assertEquals(expected, jobsService.submitJobFile(null, fileName));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(SubmitJobFileZosmfRequestRunner.class).withArguments(fileName).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.submitJobFile(fileName));
+        shouldThrow(expectedException, () -> jobsService.submitJobFile(null, fileName));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
 
         PurgeJobZosmfRequestRunner runner = mock(PurgeJobZosmfRequestRunner.class);
         PowerMockito.whenNew(PurgeJobZosmfRequestRunner.class).withArguments(jobName, jobId).thenReturn(runner);
-        jobsService.purgeJob(jobName, jobId);
+        jobsService.purgeJob(null, jobName, jobId);
 
         verify(runner).run(zosmfConnector);
     }
@@ -191,7 +191,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(PurgeJobZosmfRequestRunner.class).withArguments(jobName, jobId).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.purgeJob(jobName, jobId));
+        shouldThrow(expectedException, () -> jobsService.purgeJob(null, jobName, jobId));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         GetJobFilesZosmfRequestRunner runner = mock(GetJobFilesZosmfRequestRunner.class);
         when(runner.run(zosmfConnector)).thenReturn(expected);
         PowerMockito.whenNew(GetJobFilesZosmfRequestRunner.class).withArguments(jobName, jobId).thenReturn(runner);
-        assertEquals(expected, jobsService.getJobFiles(jobName, jobId));
+        assertEquals(expected, jobsService.getJobFiles(null, jobName, jobId));
     }
 
     @Test
@@ -222,7 +222,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(GetJobFilesZosmfRequestRunner.class).withArguments(jobName, jobId).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.getJobFiles(jobName, jobId));
+        shouldThrow(expectedException, () -> jobsService.getJobFiles(null, jobName, jobId));
     }
 
     @Test
@@ -237,7 +237,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenReturn(expected);
         PowerMockito.whenNew(GetJobFileContentZosmfRequestRunner.class).withArguments(jobName, jobId, fileId)
             .thenReturn(runner);
-        assertEquals(expected, jobsService.getJobFileContent(jobName, jobId, fileId));
+        assertEquals(expected, jobsService.getJobFileContent(null, jobName, jobId, fileId));
     }
 
     @Test
@@ -253,7 +253,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         PowerMockito.whenNew(GetJobFileContentZosmfRequestRunner.class).withArguments(jobName, jobId, fileId)
             .thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.getJobFileContent(jobName, jobId, fileId));
+        shouldThrow(expectedException, () -> jobsService.getJobFileContent(null, jobName, jobId, fileId));
     }
 
     @Test
@@ -270,7 +270,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
 
         when(runner.run(zosmfConnector)).thenReturn(expected);
 
-        assertEquals(expected, jobsService.getJobJcl(jobName, jobId));
+        assertEquals(expected, jobsService.getJobJcl(null, jobName, jobId));
     }
 
     @Test
@@ -312,7 +312,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
 
         when(runner.run(zosmfConnector)).thenThrow(subException);
 
-        shouldThrow(expectedException, () -> jobsService.getJobJcl(jobName, jobId));
+        shouldThrow(expectedException, () -> jobsService.getJobJcl(null, jobName, jobId));
     }
     
     @Test
@@ -323,7 +323,7 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
 
         ModifyJobZosmfRequestRunner runner = mock(ModifyJobZosmfRequestRunner.class);
         PowerMockito.whenNew(ModifyJobZosmfRequestRunner.class).withArguments(jobName, jobId, modifyCommand).thenReturn(runner);
-        jobsService.modifyJob(jobName, jobId, modifyCommand);
+        jobsService.modifyJob(null, jobName, jobId, modifyCommand);
 
         verify(runner).run(zosmfConnector);
     }
@@ -340,6 +340,6 @@ public class ZosmfJobsServiceTest extends ZoweApiTest {
         when(runner.run(zosmfConnector)).thenThrow(expectedException);
         PowerMockito.whenNew(ModifyJobZosmfRequestRunner.class).withArguments(jobName, jobId, modifyCommand).thenReturn(runner);
 
-        shouldThrow(expectedException, () -> jobsService.modifyJob(jobName, jobId, modifyCommand));
+        shouldThrow(expectedException, () -> jobsService.modifyJob(null, jobName, jobId, modifyCommand));
     }
 }


### PR DESCRIPTION
Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

To resolve https://github.com/zowe/jobs/issues/104

Each endpoint within the controller now also gets the http request which we then extract the IBM-X-* headers from and pass through to the zosmf services to be included in the calls sent to zosmf