### PR TITLE
Set zosmf service request so ibm headers can be propagated for v2 apis

### DIFF
--- a/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV1.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV1.java
@@ -34,7 +34,9 @@ public class JobsControllerV1 extends AbstractJobsController {
     
     @Override
     public JobsService getJobsService() {
-        jobsService.setRequest(request);
+        if(request != null ) {
+            jobsService.setRequest(request);
+        }
         return jobsService;
     }
     

--- a/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV2.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV2.java
@@ -11,6 +11,8 @@ package org.zowe.jobs.controller;
 
 import io.swagger.annotations.Api;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,8 +28,12 @@ public class JobsControllerV2 extends AbstractJobsController {
     @Qualifier("ZosmfJobsServiceV2")
     private JobsService jobsService;
 
+    @Autowired
+    private HttpServletRequest request;
+    
     @Override
     public JobsService getJobsService() {
+        jobsService.setRequest(request);
         return jobsService;
     }
 }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV2.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV2.java
@@ -33,7 +33,9 @@ public class JobsControllerV2 extends AbstractJobsController {
     
     @Override
     public JobsService getJobsService() {
-        jobsService.setRequest(request);
+        if(request != null) {
+            jobsService.setRequest(request);
+        }
         return jobsService;
     }
 }


### PR DESCRIPTION
Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

To match the V1 controller