### PR TITLE
Bump dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Development requires an API ML [Quick Start here](https://github.com/zowe/api-la
     -Dserver.ssl.keyStore=localhost.keystore.p12 \
     -Dserver.ssl.keyStorePassword=password \
     -Dserver.ssl.keyStoreType=PKCS12 \
-    -Dserver.compression.enabled=true \
     -Dconnection.httpsPort=${GATEWAY_PORT} \
     -Dconnection.ipAddress=${GATEWAY_HOST} \
     -jar $(ls -1 jobs-api-server/build/libs/jobs-api-server-*-boot.jar) &

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     ext.mavenRepositories = {
-    	mavenLocal()
+        mavenLocal()
         maven {
             url artifactoryMavenSnapshotRepo
             credentials {
@@ -29,8 +29,7 @@ buildscript {
     repositories mavenRepositories
 
     dependencies {
-        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5'
-        classpath 'com.palantir:jacoco-coverage:0.4.0'
+        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7'
         classpath 'net.researchgate:gradle-release:2.6.0'
         classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVerion}"
         classpath 'org.owasp:dependency-check-gradle:3.3.4'
@@ -38,7 +37,6 @@ buildscript {
     }
 }
 
-apply plugin: 'com.palantir.jacoco-full-report'
 apply from: 'gradle/publish.gradle'
 apply from: 'gradle/sonar.gradle'
 apply from: 'gradle/coverage.gradle'
@@ -73,7 +71,7 @@ subprojects {
     license {
         header rootProject.file('.license/LICENSE_HEADER')
         ext.year = Calendar.getInstance().get(Calendar.YEAR)
-        excludes(["**/*.yml", "**/*.json", "**/static", "**/*.sh", "**/*.txt", "**/*.p12", "**/*.xml", "**/*.jsp", "**/*.html", "**/*.jks"])
+        excludes(["**/*.yml", "**/*.yaml", "**/*.json", "**/static", "**/*.sh", "**/*.txt", "**/*.p12", "**/*.xml", "**/*.jsp", "**/*.html", "**/*.jks"])
         mapping {
             java = 'SLASHSTAR_STYLE'
         }
@@ -89,27 +87,6 @@ subprojects {
 configurations {
     all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     all*.exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-kotlin'
-}
-
-task jacocoSubProjects() {
-    subprojects.findAll { it.name in javaProjectsWithUnitTests }.each { dependsOn("${it.name}:jacocoTestReport") }
-}
-
-jacocoTestReport {
-    dependsOn test
-    reports {
-        xml.enabled true
-        html.enabled true
-    }
-}
-
-task mergeCoverage() {
-    dependsOn test, jacocoFullReport
-}
-
-task coverage() {
-    mergeCoverage.mustRunAfter jacocoSubProjects
-    dependsOn mergeCoverage, jacocoSubProjects, jacocoTestReport
 }
 
 task publishAllVersions {
@@ -144,20 +121,20 @@ release {
 
     if (releaseScope == 'minor') {
         versionPatterns = [
-            /[.]*\.(\d+)\.(\d+)[.]*/: { Matcher m, Project p -> m.replaceAll(".${(m[0][1] as int) + 1}.0") }
+                /[.]*\.(\d+)\.(\d+)[.]*/: { Matcher m, Project p -> m.replaceAll(".${(m[0][1] as int) + 1}.0") }
         ]
     } else if (releaseScope == 'major') {
         versionPatterns = [
-            /(\d+)\.(\d+)\.(\d+)[.]*/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}.0.0") }
+                /(\d+)\.(\d+)\.(\d+)[.]*/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}.0.0") }
         ]
     } else {
         versionPatterns = [
-            /(\d+)([^\d]*$)/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}${m[0][2]}") }
+                /(\d+)([^\d]*$)/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}${m[0][2]}") }
         ]
     }
 
     scmAdapters = [
-        net.researchgate.release.GitAdapter
+            net.researchgate.release.GitAdapter
     ]
 
     git {
@@ -171,5 +148,4 @@ release {
 
 afterReleaseBuild.dependsOn publishAllVersions
 //-----------Release part end
-
 

--- a/gradle/code-quality.gradle
+++ b/gradle/code-quality.gradle
@@ -2,7 +2,7 @@ allprojects {
     apply plugin: 'checkstyle'
 
     checkstyle {
-        toolVersion = '8.12'
+        toolVersion = '8.38'
         configFile = rootProject.file('codequality/checkstyle/checkstyle.xml')
         configProperties = [
             'configDir': rootProject.file('codequality/checkstyle'),

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,11 +1,14 @@
+apply plugin: 'jacoco'
+
 ext.javaProjectsWithUnitTests = [
-    'jobs-api-server',
-    'jobs-model',
-    'jobs-tests'
+        'jobs-api-server',
+        'jobs-model',
+        'jobs-tests'
 ]
 
+ext.jacocoSubProjects = subprojects.findAll { it.name in javaProjectsWithUnitTests }
 
-configure(subprojects.findAll { it.name in javaProjectsWithUnitTests }) {
+configure(jacocoSubProjects) {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'jacoco'
@@ -22,16 +25,16 @@ configure(subprojects.findAll { it.name in javaProjectsWithUnitTests }) {
                     uri: 'jacoco'
             )
             def instrumented = false
-                if (file(sourceSets.main.java.outputDir).exists()) {
-                    def instrumentedClassedDir = "${outputDir}/${sourceSets.main.java}"
-                    ant.'jacoco:instrument'(destdir: instrumentedClassedDir) {
-                        fileset(dir: sourceSets.main.java.outputDir, includes: '**/*.class')
-                    }
-                    //Replace the classes dir in the test classpath with the instrumented one
-                    sourceSets.test.runtimeClasspath -= files(sourceSets.main.java.outputDir)
-                    sourceSets.test.runtimeClasspath += files(instrumentedClassedDir)
-                    instrumented = true
+            if (file(sourceSets.main.java.outputDir).exists()) {
+                def instrumentedClassedDir = "${outputDir}/${sourceSets.main.java}"
+                ant.'jacoco:instrument'(destdir: instrumentedClassedDir) {
+                    fileset(dir: sourceSets.main.java.outputDir, includes: '**/*.class')
                 }
+                //Replace the classes dir in the test classpath with the instrumented one
+                sourceSets.test.runtimeClasspath -= files(sourceSets.main.java.outputDir)
+                sourceSets.test.runtimeClasspath += files(instrumentedClassedDir)
+                instrumented = true
+            }
             if (instrumented) {
                 //Disable class verification based on https://github.com/jayway/powermock/issues/375
                 test.jvmArgs += '-noverify'
@@ -39,9 +42,9 @@ configure(subprojects.findAll { it.name in javaProjectsWithUnitTests }) {
         }
     }
     test.dependsOn instrument
-    
+
     jacoco {
-        toolVersion = '0.8.2'
+        toolVersion = '0.8.3'
     }
 
     jacocoTestReport {
@@ -50,5 +53,46 @@ configure(subprojects.findAll { it.name in javaProjectsWithUnitTests }) {
             xml.enabled true
             html.enabled true
         }
+        afterEvaluate {
+            executionData.setFrom(files(executionData.files.collect {
+                fileTree(dir: it, exclude: 'jobs-tests/**')
+            }))
+        }
     }
+}
+
+task jacocoFullReport(type: JacocoReport) {
+    description = 'Generates an aggregate report from all subprojects'
+    dependsOn(jacocoSubProjects.jacocoTestReport)
+
+    getAdditionalSourceDirs().from(
+            files(jacocoSubProjects.sourceSets.main.allSource.srcDirs)
+    )
+
+    getSourceDirectories().from(
+            files(jacocoSubProjects.sourceSets.main.allSource.srcDirs)
+    )
+
+    getClassDirectories().from(
+            files(jacocoSubProjects.sourceSets.main.output)
+    )
+
+    getExecutionData().from(
+            files(jacocoSubProjects.jacocoTestReport.executionData)
+    )
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+    }
+
+    doFirst {
+        getExecutionData().from(
+                files(executionData.findAll { it.exists() })
+        )
+    }
+}
+
+task coverage() {
+    dependsOn jacocoFullReport
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -14,6 +14,7 @@ ext.publishTasksList = projectsToPublish.collect { ":" + it + ":publish" }
 configure(subprojects.findAll { it.name in projectsToPublish }) {
     apply plugin: "maven"
     apply plugin: 'maven-publish'
+    apply plugin: 'java'
 
     publishing {
         repositories.maven {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,7 +14,7 @@ ext {
     junitVersion = "4.13.1"
     restAssuredVersion = "4.3.0"
     javaxValidationApiVersion= "2.0.1.Final"
-    explorerApiCommonVersion = "1.1.6-CARSON-BUMP-SPRING-SNAPSHOT"
+    explorerApiCommonVersion = "1.1.6"
 
     libraries = [
             lombok                             : "org.projectlombok:lombok:${lombokVersion}",

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -12,6 +12,7 @@ ext {
     slf4jVersion = "1.7.25"
     jsonPathVersion = "2.4.0"
     junitVersion = "4.12"
+    restAssuredVersion = "4.3.0"
     explorerApiCommonVersion = "1.1.4"
 
     libraries = [
@@ -23,6 +24,7 @@ ext {
         spring_boot_starter_parent         : "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}",
         spring_boot_starter_security       : "org.springframework.boot:spring-boot-starter-security:${springBootVersion}",
         spring_boot_starter_web            : "org.springframework.boot:spring-boot-starter-web:${springBootVersion}",
+        spring_boot_start_validation       : "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}",
         spring_boot_starter_test           : "org.springframework.boot:spring-boot-starter-test:${springBootVersion}",
 
         commons_codec                      : "commons-codec:commons-codec:${commonsCodecVersion}",
@@ -42,6 +44,7 @@ ext {
         mockito_core                       : "org.mockito:mockito-core:${mockitoCoreVersion}",
 
         junit                              : "junit:junit:${junitVersion}",
+        restAssured                        : "io.rest-assured:rest-assured:${restAssuredVersion}",
 
         explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:${explorerApiCommonVersion}",
         explorer_api_common_test           : "org.zowe.explorer.api:explorer-api-common-test:${explorerApiCommonVersion}"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,7 +14,7 @@ ext {
     junitVersion = "4.13.1"
     restAssuredVersion = "4.3.0"
     javaxValidationApiVersion= "2.0.1.Final"
-    explorerApiCommonVersion = "1.1.5"
+    explorerApiCommonVersion = "1.1.6-CARSON-BUMP-SPRING-SNAPSHOT"
 
     libraries = [
             lombok                             : "org.projectlombok:lombok:${lombokVersion}",

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,52 +1,53 @@
 ext {
 
-    springBootVersion = '2.1.7.RELEASE'
-    springFoxVersion = '2.8.0'
+    springBootVersion = '2.3.9.RELEASE'
+    springFoxVersion = '3.0.0'
     lombokVersion = '1.16.20'
     mockitoCoreVersion = '2.23.4'
     powerMockVersion = "2.0.0-RC.1"
     gsonVersion = '2.8.2'
-    httpClientVersion = '4.5.3'
+    httpClientVersion = '4.5.13'
     httpCoreVersion = '4.4.10'
     commonsCodecVersion = '1.11'
     slf4jVersion = "1.7.25"
     jsonPathVersion = "2.4.0"
-    junitVersion = "4.12"
+    junitVersion = "4.13.1"
     restAssuredVersion = "4.3.0"
-    explorerApiCommonVersion = "1.1.4"
+    javaxValidationApiVersion= "2.0.1.Final"
+    explorerApiCommonVersion = "1.1.5"
 
     libraries = [
-        lombok                             : "org.projectlombok:lombok:${lombokVersion}",
-        slf4j_simple                       : "org.slf4j:slf4j-simple:${slf4jVersion}",
-        slf4j_api                          : "org.slf4j:slf4j-api:${slf4jVersion}",
-        spring_boot_gradle_plugin          : "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}",
-        spring_boot_starter_actuator       : "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}",
-        spring_boot_starter_parent         : "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}",
-        spring_boot_starter_security       : "org.springframework.boot:spring-boot-starter-security:${springBootVersion}",
-        spring_boot_starter_web            : "org.springframework.boot:spring-boot-starter-web:${springBootVersion}",
-        spring_boot_start_validation       : "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}",
-        spring_boot_starter_test           : "org.springframework.boot:spring-boot-starter-test:${springBootVersion}",
+            lombok                             : "org.projectlombok:lombok:${lombokVersion}",
+            slf4j_simple                       : "org.slf4j:slf4j-simple:${slf4jVersion}",
+            slf4j_api                          : "org.slf4j:slf4j-api:${slf4jVersion}",
+            spring_boot_gradle_plugin          : "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}",
+            spring_boot_starter_actuator       : "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}",
+            spring_boot_starter_parent         : "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}",
+            spring_boot_starter_security       : "org.springframework.boot:spring-boot-starter-security:${springBootVersion}",
+            spring_boot_starter_web            : "org.springframework.boot:spring-boot-starter-web:${springBootVersion}",
+            spring_boot_start_validation       : "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}",
+            spring_boot_starter_test           : "org.springframework.boot:spring-boot-starter-test:${springBootVersion}",
 
-        commons_codec                      : "commons-codec:commons-codec:${commonsCodecVersion}",
-        json_path                          : "com.jayway.jsonpath:json-path:${jsonPathVersion}",
-        springFox                          : "io.springfox:springfox-swagger2:${springFoxVersion}",
-        springFoxSwagger2                  : "io.springfox:springfox-swagger2:${springFoxVersion}",
-        springFoxSwaggerUI                 : "io.springfox:springfox-swagger-ui:${springFoxVersion}",
+            commons_codec                      : "commons-codec:commons-codec:${commonsCodecVersion}",
+            json_path                          : "com.jayway.jsonpath:json-path:${jsonPathVersion}",
+            springFox                          : "io.springfox:springfox-swagger2:${springFoxVersion}",
+            springFoxSwagger2                  : "io.springfox:springfox-swagger2:${springFoxVersion}",
+            springFoxSwaggerUI                 : "io.springfox:springfox-swagger-ui:${springFoxVersion}",
 
-        http_core                          : "org.apache.httpcomponents:httpcore:${httpCoreVersion}",
-        http_client                        : "org.apache.httpcomponents:httpclient:${httpClientVersion}",
-    
-        powermock_api_mockito2             : "org.powermock:powermock-api-mockito2:${powerMockVersion}",
-        power_mock_junit4                  : "org.powermock:powermock-module-junit4:${powerMockVersion}",
-        power_mock_junit4_rule             : "org.powermock:powermock-module-junit4-rule:${powerMockVersion}",
-    
-        gson                               : "com.google.code.gson:gson:${gsonVersion}",
-        mockito_core                       : "org.mockito:mockito-core:${mockitoCoreVersion}",
+            http_core                          : "org.apache.httpcomponents:httpcore:${httpCoreVersion}",
+            http_client                        : "org.apache.httpcomponents:httpclient:${httpClientVersion}",
 
-        junit                              : "junit:junit:${junitVersion}",
-        restAssured                        : "io.rest-assured:rest-assured:${restAssuredVersion}",
+            powermock_api_mockito2             : "org.powermock:powermock-api-mockito2:${powerMockVersion}",
+            power_mock_junit4                  : "org.powermock:powermock-module-junit4:${powerMockVersion}",
+            power_mock_junit4_rule             : "org.powermock:powermock-module-junit4-rule:${powerMockVersion}",
 
-        explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:${explorerApiCommonVersion}",
-        explorer_api_common_test           : "org.zowe.explorer.api:explorer-api-common-test:${explorerApiCommonVersion}"
+            gson                               : "com.google.code.gson:gson:${gsonVersion}",
+            mockito_core                       : "org.mockito:mockito-core:${mockitoCoreVersion}",
+
+            junit                              : "junit:junit:${junitVersion}",
+            restAssured						   : "io.rest-assured:rest-assured:${restAssuredVersion}",
+
+            explorer_api_common                : "org.zowe.explorer.api:explorer-api-common:${explorerApiCommonVersion}",
+            explorer_api_common_test           : "org.zowe.explorer.api:explorer-api-common-test:${explorerApiCommonVersion}"
     ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jobs-api-server/build.gradle
+++ b/jobs-api-server/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile libraries.springFoxSwagger2
     compile libraries.springFoxSwaggerUI
     compile libraries.lombok
+    annotationProcessor libraries.lombok
     compile libraries.explorer_api_common
 
     testCompile libraries.spring_boot_starter_test

--- a/jobs-api-server/src/main/java/org/zowe/jobs/JesJobsApplication.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/JesJobsApplication.java
@@ -10,6 +10,7 @@
 package org.zowe.jobs;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV1.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV1.java
@@ -34,7 +34,7 @@ public class JobsControllerV1 extends AbstractJobsController {
     
     @Override
     public JobsService getJobsService() {
-        if(request != null ) {
+        if (request != null ) {
             jobsService.setRequest(request);
         }
         return jobsService;

--- a/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV2.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/controller/JobsControllerV2.java
@@ -11,13 +11,13 @@ package org.zowe.jobs.controller;
 
 import io.swagger.annotations.Api;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.zowe.jobs.services.JobsService;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api/v2/jobs")
@@ -33,7 +33,7 @@ public class JobsControllerV2 extends AbstractJobsController {
     
     @Override
     public JobsService getJobsService() {
-        if(request != null) {
+        if (request != null) {
             jobsService.setRequest(request);
         }
         return jobsService;

--- a/jobs-api-server/src/main/resources/application.yaml
+++ b/jobs-api-server/src/main/resources/application.yaml
@@ -37,7 +37,7 @@ server:
     enabled-protocols: TLSv1.2
     ciphers: ${apiml.security.ssl.ciphers}
   compression:
-    enabled: ${server.compression.enabled}
+    enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css
     
 zosmf:

--- a/jobs-api-server/src/test/java/org/zowe/jobs/controller/JobsControllerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/controller/JobsControllerTest.java
@@ -93,7 +93,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobs("TESTNAME", "*", JobStatus.ALL)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}&owner={owner}", "TESTNAME", "*"))
-            .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
         verify(jobsService, times(1)).getJobs("TESTNAME", "*", JobStatus.ALL);
@@ -113,7 +113,7 @@ public class JobsControllerTest extends ApiControllerTest {
         mockMvc
             .perform(get(ENDPOINT_ROOT + "?prefix={prefix}&owner={owner}&status={status}", "TESTNAME", "*",
                     JobStatus.ACTIVE))
-            .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
         verify(jobsService, times(1)).getJobs("TESTNAME", "*", JobStatus.ACTIVE);
@@ -131,7 +131,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobs("TESTNAME", null, JobStatus.ALL)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}", "TESTNAME")).andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
         verify(jobsService, times(1)).getJobs("TESTNAME", null, JobStatus.ALL);
@@ -146,7 +146,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobs("TESTNAME", null, JobStatus.ALL)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "?prefix={prefix}", "TESTNAME")).andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(EMPTY_ITEMS));
 
         verify(jobsService, times(1)).getJobs("TESTNAME", null, JobStatus.ALL);
@@ -180,7 +180,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJob("TESTNAME", "TESTID11")).thenReturn(dummyJob);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}", "TESTNAME", "TESTID11")).andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)));
 
         verify(jobsService, times(1)).getJob("TESTNAME", "TESTID11");
@@ -219,7 +219,7 @@ public class JobsControllerTest extends ApiControllerTest {
         doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).getJob(jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/", jobName, jobId)).andExpect(status().isIAmATeapot())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
 
@@ -242,7 +242,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobFiles(jobName, jobId)).thenReturn(items);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files", jobName, jobId)).andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(items)));
 
         verify(jobsService, times(1)).getJobFiles(jobName, jobId);
@@ -282,7 +282,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobFileContent(jobName, jobId, fileId)).thenReturn(jobFileContent);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/{fileId}/content", jobName, jobId, fileId))
-            .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(jobFileContent)));
 
         verify(jobsService, times(1)).getJobFileContent(jobName, jobId, fileId);
@@ -325,7 +325,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobFiles(jobName, jobId)).thenReturn(items);
         
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files", jobName, jobId)).andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(content().string(JsonUtils.convertToJsonString(items)));
         
         JobFileContent jobFileContent1 = new JobFileContent("1 //ATLJ0000 JOB (ADL),'ATLAS',MSGCLASS=X,CLASS=A,TIME=1440               JOB21849\\n");
@@ -337,16 +337,16 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.getJobFileContent(jobName, jobId, fileId2)).thenReturn(jobFileContent2);
         
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/{fileId}/content", jobName, jobId, fileId1))
-        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(content().string(JsonUtils.convertToJsonString(jobFileContent1)));
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/{fileId}/content", jobName, jobId, fileId2))
-        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(content().string(JsonUtils.convertToJsonString(jobFileContent2)));
         
         JobFileContent concatenatedContent = new JobFileContent(jobFileContent1.getContent() + jobFileContent2.getContent());
         
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/files/content", jobName, jobId))
-        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(content().string(JsonUtils.convertToJsonString(concatenatedContent)));
     }
 
@@ -365,7 +365,7 @@ public class JobsControllerTest extends ApiControllerTest {
             .thenReturn(new JobFileContent(loadFile("src/test/resources/testData/JESJCL")));
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/steps", jobName, jobId)).andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(expected)));
 
         verify(jobsService, times(1)).getJobJcl(jobName, jobId);
@@ -406,7 +406,7 @@ public class JobsControllerTest extends ApiControllerTest {
         doThrow(new JobJesjclNotFoundException(jobName, jobId)).when(jobsService).getJobJcl(jobName, jobId);
 
         mockMvc.perform(get(ENDPOINT_ROOT + "/{jobName}/{jobId}/steps", jobName, jobId))
-            .andExpect(status().isIAmATeapot()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(status().isIAmATeapot()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(expectedError.getMessage()));
 
@@ -453,7 +453,7 @@ public class JobsControllerTest extends ApiControllerTest {
         request.add(new SimpleJob(jobName, jobId));
         request.add(new SimpleJob(jobName, jobId));
 
-        mockMvc.perform(delete(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        mockMvc.perform(delete(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(JsonUtils.convertToJsonString(request))).andExpect(status().isNoContent())
             .andExpect(jsonPath("$").doesNotExist());
 
@@ -474,7 +474,7 @@ public class JobsControllerTest extends ApiControllerTest {
 
         doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).purgeJob(jobName, jobId);
 
-        mockMvc.perform(delete(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        mockMvc.perform(delete(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(JsonUtils.convertToJsonString(request)))
             .andExpect(status().isIAmATeapot()).andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
@@ -491,7 +491,7 @@ public class JobsControllerTest extends ApiControllerTest {
         ModifyJobRequest request = new ModifyJobRequest("cancel");
         
         mockMvc.perform(put(ENDPOINT_ROOT + "/{jobName}/{jobId}", jobName, jobId)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE).content(JsonUtils.convertToJsonString(request)))
+                .contentType(MediaType.APPLICATION_JSON_VALUE).content(JsonUtils.convertToJsonString(request)))
                 .andExpect(status().isAccepted());
         
         verify(jobsService, times(1)).modifyJob(jobName, jobId, request.getCommand());
@@ -512,7 +512,7 @@ public class JobsControllerTest extends ApiControllerTest {
         doThrow(new ZoweApiErrorException(expectedError)).when(jobsService).modifyJob(jobName, jobId, request.getCommand());
         
         mockMvc.perform(put(ENDPOINT_ROOT + "/{jobName}/{jobId}", jobName, jobId)
-            .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE).content(JsonUtils.convertToJsonString(request)))
+            .contentType(MediaType.APPLICATION_JSON_VALUE).content(JsonUtils.convertToJsonString(request)))
             .andExpect(status().isNotFound()).andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
         
@@ -530,7 +530,7 @@ public class JobsControllerTest extends ApiControllerTest {
         jobList.add(new SimpleJob(jobName, jobId));
         ModifyMultipleJobsRequest modifyRequest = new ModifyMultipleJobsRequest(modifyCommand, jobList);
         
-        mockMvc.perform(put(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        mockMvc.perform(put(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(JsonUtils.convertToJsonString(modifyRequest)))
             .andExpect(status().isAccepted()).andExpect(jsonPath("$").doesNotExist());
 
@@ -555,9 +555,9 @@ public class JobsControllerTest extends ApiControllerTest {
         mockJobUriConstruction(jobName, jobId, locationUri);
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(request)))
-            .andExpect(status().isCreated()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(status().isCreated()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)))
             .andExpect(header().string("Location", locationUri.toString()));
 
@@ -573,9 +573,9 @@ public class JobsControllerTest extends ApiControllerTest {
         ApiError expectedError = ApiError.builder().message(errorMessage).status(HttpStatus.BAD_REQUEST).build();
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(new SubmitJobStringRequest(""))))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
         verifyNoMoreInteractions(jobsService);
@@ -592,7 +592,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.submitJobString(dummyJcl)).thenThrow(new ZoweApiErrorException(expectedError));
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(new SubmitJobStringRequest(dummyJcl))))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));
@@ -615,9 +615,9 @@ public class JobsControllerTest extends ApiControllerTest {
         mockJobUriConstruction(jobName, jobId, locationUri);
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/dataset").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+            .perform(post(ENDPOINT_ROOT + "/dataset").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(request)))
-            .andExpect(status().isCreated()).andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .andExpect(status().isCreated()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)))
             .andExpect(header().string("Location", locationUri.toString()));
 
@@ -635,7 +635,7 @@ public class JobsControllerTest extends ApiControllerTest {
         when(jobsService.submitJobFile(dummyDataSet)).thenThrow(new ZoweApiErrorException(expectedError));
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/dataset").contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+            .perform(post(ENDPOINT_ROOT + "/dataset").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(new SubmitJobFileRequest(dummyDataSet))))
             .andExpect(jsonPath("$.status").value(expectedError.getStatus().name()))
             .andExpect(jsonPath("$.message").value(errorMessage));

--- a/jobs-model/build.gradle
+++ b/jobs-model/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     compile libraries.spring_boot_starter_actuator
     compile libraries.spring_boot_starter_parent
     compile libraries.spring_boot_starter_security
+    compile libraries.spring_boot_start_validation
     compile libraries.spring_boot_starter_web
     compile libraries.http_core
     compile libraries.http_client
@@ -12,6 +13,7 @@ dependencies {
     compile libraries.springFoxSwagger2
     compile libraries.springFoxSwaggerUI
     compile libraries.lombok
+    annotationProcessor libraries.lombok
 
     testCompile libraries.spring_boot_starter_test
     testCompile libraries.powermock_api_mockito2

--- a/jobs-model/src/main/java/org/zowe/jobs/model/ModifyMultipleJobsRequest.java
+++ b/jobs-model/src/main/java/org/zowe/jobs/model/ModifyMultipleJobsRequest.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2019
+ */
 package org.zowe.jobs.model;
 
 import io.swagger.annotations.ApiModelProperty;

--- a/jobs-model/src/main/java/org/zowe/jobs/model/SimpleJob.java
+++ b/jobs-model/src/main/java/org/zowe/jobs/model/SimpleJob.java
@@ -1,6 +1,16 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2019
+ */
 package org.zowe.jobs.model;
 
 import io.swagger.annotations.ApiModelProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/jobs-tests/build.gradle
+++ b/jobs-tests/build.gradle
@@ -11,29 +11,31 @@ ext {
 }
 
 dependencies {
-    compile project(':jobs-model')
-    compile project(':jobs-api-server')
-    compile libraries.spring_boot_starter_actuator
-    compile libraries.spring_boot_starter_parent
-    compile libraries.spring_boot_starter_security
-    compile libraries.spring_boot_starter_web
-    compile libraries.http_core
-    compile libraries.http_client
-    compile libraries.commons_codec
-    compile libraries.gson
-    compile libraries.springFox
-    compile libraries.springFoxSwagger2
-    compile libraries.springFoxSwaggerUI
-    compile libraries.lombok
-    compile libraries.explorer_api_common
+	compile project(':jobs-model')
+	compile project(':jobs-api-server')
+	compile libraries.spring_boot_starter_actuator
+	compile libraries.spring_boot_starter_parent
+	compile libraries.spring_boot_starter_security
+	compile libraries.spring_boot_starter_web
+	compile libraries.http_core
+	compile libraries.http_client
+	compile libraries.commons_codec
+	compile libraries.gson
+	compile libraries.springFox
+	compile libraries.springFoxSwagger2
+	compile libraries.springFoxSwaggerUI
+	compile libraries.explorer_api_common
+	compile libraries.restAssured
+	compile libraries.lombok
+	annotationProcessor libraries.lombok
 
-    testCompile libraries.spring_boot_starter_test
-    testCompile libraries.powermock_api_mockito2
-    testCompile libraries.power_mock_junit4
-    testCompile libraries.power_mock_junit4_rule
-    testCompile libraries.mockito_core
-    testCompile libraries.explorer_api_common_test
-    testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0' //TODO testCompile libraries.hamcrest
+	testCompile libraries.spring_boot_starter_test
+	testCompile libraries.powermock_api_mockito2
+	testCompile libraries.power_mock_junit4
+	testCompile libraries.power_mock_junit4_rule
+	testCompile libraries.mockito_core
+	testCompile libraries.explorer_api_common_test
+	testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0' //TODO testCompile libraries.hamcrest
 }
 
 test {
@@ -44,24 +46,26 @@ test {
 	systemProperty "test.version", test_version
 
 	reports.junitXml.destination = file(
-		file(reports.junitXml.destination).getParent() + 
-		"/test-" + 
-		test_version
+			file(reports.junitXml.destination).getParent() +
+					"/test-" +
+					test_version
 	)
 	reports.html.destination = file(
-		file(reports.html.destination).getParent() + 
-		"/test-" + 
-		test_version
+			file(reports.html.destination).getParent() +
+					"/test-" +
+					test_version
 	)
 }
 
-task validate << {
-	checkAndThrow("server_host", "undefined", "server.host");
-	checkAndThrow("server_port", -1, "server.port");
-	checkAndThrow("username", "undefined", "server.username");
-	checkAndThrow("password", "undefined", "server.password");
-	checkAndThrow("test_version", "undefined", "test.version");
-}	
+task validate {
+	doLast {
+		checkAndThrow("server_host", "undefined", "server.host");
+		checkAndThrow("server_port", -1, "server.port");
+		checkAndThrow("username", "undefined", "server.username");
+		checkAndThrow("password", "undefined", "server.password");
+		checkAndThrow("test_version", "undefined", "test.version");
+	}
+}
 
 task runIntegrationTests(dependsOn: ['validate', 'test']){
 
@@ -73,15 +77,14 @@ void checkAndThrow(String property, defaultValue, required=property) {
 	}
 }
 
-gradle.taskGraph.whenReady { taskGraph -> 
+gradle.taskGraph.whenReady { taskGraph ->
 	if (!taskGraph.hasTask(runIntegrationTests)) {
 		def tasks = taskGraph.getAllTasks()
-		tasks.findAll { it.name == 'test' }.each { task -> 
+		tasks.findAll { it.name == 'test' }.each { task ->
 			if (task.getProject().getName() == 'jobs-tests') {
-		 		task.setEnabled(false) 
+				task.setEnabled(false)
 			}
 		}
 	}
-} 
-
+}
 

--- a/jobs-tests/src/test/java/org/zowe/jobs/tests/JobDeleteIntegrationTest.java
+++ b/jobs-tests/src/test/java/org/zowe/jobs/tests/JobDeleteIntegrationTest.java
@@ -19,9 +19,9 @@ import org.zowe.jobs.model.Job;
 import org.zowe.jobs.model.JobStatus;
 import org.zowe.jobs.model.SimpleJob;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-
 import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.equalTo;
 
 public class JobDeleteIntegrationTest extends AbstractJobsIntegrationTest {
 

--- a/jobs-tests/src/test/java/org/zowe/jobs/tests/JobGetByIdTest.java
+++ b/jobs-tests/src/test/java/org/zowe/jobs/tests/JobGetByIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This program and the accompanying materials are made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
@@ -7,7 +7,6 @@
  *
  * Copyright IBM Corporation 2016, 2020
  */
-
 package org.zowe.jobs.tests;
 
 import io.restassured.http.ContentType;
@@ -49,13 +48,19 @@ public class JobGetByIdTest extends AbstractJobsIntegrationTest {
 
     @Test
     public void testGetJobByNameAndId() throws Exception {
-        Job actualJob = getJob(job).then().statusCode(HttpStatus.SC_OK).extract().body().as(Job.class);
+        Job actualJob = getJob(job).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .extract().body().as(Job.class);
         verifyJobIsAsExpected(actualJob);
     }
 
     @Test
     public void testGetJobByNameWithHashAndId() throws Exception {
-        Job actualJob = getJob(jobWithHash).then().statusCode(HttpStatus.SC_OK).extract().body().as(Job.class);
+        Job actualJob = getJob(jobWithHash).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .extract().body().as(Job.class);
         verifyInProgressJobIsAsExpected(actualJob);
     }
 
@@ -63,8 +68,11 @@ public class JobGetByIdTest extends AbstractJobsIntegrationTest {
     public void testGetJobByNameAndNonexistingId() throws Exception {
         ApiError expectedError = ApiError.builder().status(org.springframework.http.HttpStatus.NOT_FOUND)
             .message(String.format("No job with name '%s' and id '%s' was found", job.getJobName(), "z000000")).build();
-        getJob(job.getJobName(), "z000000").then().statusCode(expectedError.getStatus().value())
-            .contentType(ContentType.JSON).body("status", equalTo(expectedError.getStatus().name()))
+        getJob(job.getJobName(), "z000000").then()
+            .statusCode(expectedError.getStatus().value())
+            .header("Content-Encoding", "gzip")
+            .contentType(ContentType.JSON)
+            .body("status", equalTo(expectedError.getStatus().name()))
             .body("message", equalTo(expectedError.getMessage()));
     }
 }

--- a/jobs-tests/src/test/java/org/zowe/jobs/tests/JobModifyIntegrationTest.java
+++ b/jobs-tests/src/test/java/org/zowe/jobs/tests/JobModifyIntegrationTest.java
@@ -10,12 +10,12 @@
 
 package org.zowe.jobs.tests;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 import org.apache.http.HttpStatus;
 import org.junit.BeforeClass;

--- a/jobs-tests/src/test/java/org/zowe/jobs/tests/JobsGetIntegrationTest.java
+++ b/jobs-tests/src/test/java/org/zowe/jobs/tests/JobsGetIntegrationTest.java
@@ -47,7 +47,10 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
 
     @Test
     public void testGetJobs() {
-        List<Job> actual = getJobs(null, null).then().statusCode(HttpStatus.SC_OK).extract().body().jsonPath()
+        List<Job> actual = getJobs(null, null).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .extract().body().jsonPath()
             .getList("items", Job.class);
 
         // We have results, they are of type job and all have owner = user
@@ -60,7 +63,10 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
     @Test
     public void testGetJobsWithUnlikelyPrefix() {
         String prefix = "12345678";
-        getJobs(prefix, null).then().statusCode(HttpStatus.SC_OK).body("items", IsEmptyCollection.empty());
+        getJobs(prefix, null).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .body("items", IsEmptyCollection.empty());
     }
 
     @Test
@@ -70,7 +76,10 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
 
         ApiError expectedError = expected.getApiError();
 
-        getJobs(prefix, null).then().statusCode(expectedError.getStatus().value()).contentType(ContentType.JSON)
+        getJobs(prefix, null).then()
+            .statusCode(expectedError.getStatus().value())
+            .header("Content-Encoding", "gzip")
+            .contentType(ContentType.JSON)
             .body("status", equalTo(expectedError.getStatus().name()))
             .body("message", equalTo(expectedError.getMessage()));
     }
@@ -88,7 +97,10 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
 
         ApiError expectedError = expected.getApiError();
 
-        getJobs(null, owner).then().statusCode(expectedError.getStatus().value()).contentType(ContentType.JSON)
+        getJobs(null, owner).then()
+            .statusCode(expectedError.getStatus().value())
+            .header("Content-Encoding", "gzip")
+            .contentType(ContentType.JSON)
             .body("status", equalTo(expectedError.getStatus().name()))
             .body("message", equalTo(expectedError.getMessage()));
     }
@@ -101,16 +113,21 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
 
         ApiError expectedError = expected.getApiError();
 
-        getJobs(null, owner).then().statusCode(expectedError.getStatus().value()).contentType(ContentType.JSON)
+        getJobs(null, owner).then()
+            .statusCode(expectedError.getStatus().value())
+            .header("Content-Encoding", "gzip")
+            .contentType(ContentType.JSON)
             .body("status", equalTo(expectedError.getStatus().name())).body("message",
                     equalTo("An invalid job owner of '*s23y3&lt;script&gt;alert(1)&lt;/script&gt;vpgqn' was supplied"));
     }
 
     @Test
     public void testGetJobsWithOwnerAndPrefix() {
-        String owner = USER;
         String prefix = job.getJobName();
-        List<Job> actual = getJobs(prefix, owner).then().statusCode(HttpStatus.SC_OK).extract().body().jsonPath()
+        List<Job> actual = getJobs(prefix, USER).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .extract().body().jsonPath()
             .getList("items", Job.class);
 
         // We have results, they are of type job and all have owner = user and prefix
@@ -122,9 +139,12 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
     }
 
     @Test
-    public void testGetJobsWithCurrentUserAsOwnerAndSpecificPrefix() throws Exception {
+    public void testGetJobsWithCurrentUserAsOwnerAndSpecificPrefix() {
         String prefix = job.getJobName();
-        List<Job> actual = getJobs(prefix, null).then().statusCode(HttpStatus.SC_OK).extract().body().jsonPath()
+        List<Job> actual = getJobs(prefix, null).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .extract().body().jsonPath()
             .getList("items", Job.class);
 
         // We have results, they are of type job and all have owner = user and prefix
@@ -136,8 +156,11 @@ public class JobsGetIntegrationTest extends AbstractJobsIntegrationTest {
     }
 
     @Test
-    public void testGetJobsWithCurrentUserAsOwnerSpecificPrefixAndStatus() throws Exception {
-        List<Job> actual = getJobs(null, null, JobStatus.OUTPUT).then().statusCode(HttpStatus.SC_OK).extract().body()
+    public void testGetJobsWithCurrentUserAsOwnerSpecificPrefixAndStatus() {
+        List<Job> actual = getJobs(null, null, JobStatus.OUTPUT).then()
+            .statusCode(HttpStatus.SC_OK)
+            .header("Content-Encoding", "gzip")
+            .extract().body()
             .jsonPath().getList("items", Job.class);
 
         // We have results, they are of type job and all have owner = user and status OUTPUT

--- a/jobs-tests/src/test/java/org/zowe/jobs/tests/JobsLogoutIntegrationTest.java
+++ b/jobs-tests/src/test/java/org/zowe/jobs/tests/JobsLogoutIntegrationTest.java
@@ -11,8 +11,6 @@ package org.zowe.jobs.tests;
 
 import io.restassured.RestAssured;
 
-import static org.junit.Assume.assumeTrue;
-
 import org.apache.http.HttpStatus;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -20,6 +18,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.zowe.jobs.model.Job;
 import org.zowe.jobs.model.JobStatus;
+
+import static org.junit.Assume.assumeTrue;
 
 public class JobsLogoutIntegrationTest extends AbstractJobsIntegrationTest {
 

--- a/jobs-zowe-server-package/src/main/resources/bin/start.sh
+++ b/jobs-zowe-server-package/src/main/resources/bin/start.sh
@@ -37,7 +37,6 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${COMPONENT_CODE} java \
   -Dserver.ssl.keyStoreType=${KEYSTORE_TYPE} \
   -Dserver.connection-timeout=8000 \
   -Dcom.ibm.jsse2.overrideDefaultTLS=true \
-  -Dserver.compression.enabled=true \
   -Dconnection.httpsPort=${GATEWAY_PORT} \
   -Dconnection.ipAddress=${ZOWE_EXPLORER_HOST} \
   -Dspring.main.banner-mode=off \

--- a/scripts/prepare-fvt.sh
+++ b/scripts/prepare-fvt.sh
@@ -254,7 +254,6 @@ java -Xms16m -Xmx512m \
     -Dserver.ssl.keyStore=${FVT_WORKSPACE}/${FVT_KEYSTORE_DIR}/localhost.keystore.p12 \
     -Dserver.ssl.keyStorePassword=password \
     -Dserver.ssl.keyStoreType=PKCS12 \
-    -Dserver.compression.enabled=true \
     -Dconnection.httpsPort=${FVT_GATEWAY_PORT} \
     -Dconnection.ipAddress=localhost \
     -Dspring.main.banner-mode=off \


### PR DESCRIPTION
Upgrades dependencies. Upgrading Spring caused required a new gradle version, which changed how test coverage had to be reported. The new spring version also required some updates to test expected values.

There were also some formatting changes to allow the local ./gradlew build to pass the checkstyle test.

Finally, because the new spring affects compression, compression was enabled by default and tested for in relevant integration tests.