### PR TITLE
Set springfox to 2.9.2

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,7 +1,7 @@
 ext {
     springBootVersion = '2.3.12.RELEASE'
     springSecurityVersion = '5.3.11.RELEASE!!'
-    springFoxVersion = '3.0.0'
+    springFoxVersion = '2.9.2'
     lombokVersion = '1.16.20'
     mockitoCoreVersion = '2.23.4'
     powerMockVersion = "2.0.0-RC.1"


### PR DESCRIPTION
Known issue in springfox 3.0.0 handling void responses.

Signed-off-by: Carson Cook <carson.cook@ibm.com>