### PR TITLE
Split swagger doc

### DIFF
--- a/jobs-api-server/src/main/java/org/zowe/jobs/controller/AbstractJobsController.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/controller/AbstractJobsController.java
@@ -56,7 +56,7 @@ public abstract class AbstractJobsController {
     
     abstract JobsService getJobsService();
     
-    @GetMapping(value = "", produces = { "application/json" })
+    @GetMapping(value = "/", produces = { "application/json" })
     @ApiOperation(value = "Get a list of jobs", nickname = "getJobs", notes = "This API returns the a list of jobs for a given prefix and owner.", response = Job.class, responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok") })
     public ItemsWrapper<Job> getJobs(
@@ -90,7 +90,7 @@ public abstract class AbstractJobsController {
         return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
     }
     
-    @DeleteMapping(value = "", produces = { "application/json" })
+    @DeleteMapping(value = "/", produces = { "application/json" })
     @ApiOperation(value = "Given a list of jobs Cancel and Purge them all", nickname = "purgeJobs", notes = "This API purges all jobs provided")
     @ApiResponses(value = { @ApiResponse(code = 204, message = "Job purges succesfully requested") })
     public ResponseEntity<Void> purgeJobs(@RequestBody List<SimpleJob> jobList) {
@@ -111,7 +111,7 @@ public abstract class AbstractJobsController {
         return ResponseEntity.accepted().build();
     }
     
-    @PutMapping(value = "", produces = { "application/json" })
+    @PutMapping(value = "/", produces = { "application/json" })
     @ApiOperation(value = "Given a list of jobs issue a Modify command for each", nickname = "modifyJobs", notes = "This API modifies all jobs provided")
     @ApiResponses(value = { @ApiResponse(code = 202, message = "Job modifies requested") })
     public ResponseEntity<Void> modifyJobs(@RequestBody ModifyMultipleJobsRequest request) {

--- a/jobs-api-server/src/main/java/org/zowe/jobs/spring/SwaggerConfig.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/spring/SwaggerConfig.java
@@ -27,12 +27,39 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("all")
                 .select()
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.regex("/api.*"))
                 .build()
                 .apiInfo(
-                    new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "1.0", null, null, null, null, Collections.emptyList())
+                    new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "2.0", null, null, null, null, Collections.emptyList())
+                );
+    }
+
+    @Bean
+    public Docket apiV1() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("v1")
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.regex("/api/v1.*"))
+                .build()
+                .apiInfo(
+                        new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "1.0", null, null, null, null, Collections.emptyList())
+                );
+    }
+
+    @Bean
+    public Docket apiv2() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("v2")
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.regex("/api/v2.*"))
+                .build()
+                .apiInfo(
+                        new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "2.0", null, null, null, null, Collections.emptyList())
                 );
     }
 }

--- a/jobs-api-server/src/main/java/org/zowe/jobs/spring/SwaggerConfig.java
+++ b/jobs-api-server/src/main/java/org/zowe/jobs/spring/SwaggerConfig.java
@@ -24,6 +24,9 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
+    private static final String TITLE = "JES Jobs API";
+    private static final String DESCRIPTION = "REST API for the JES Jobs Service";
+
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
@@ -33,7 +36,7 @@ public class SwaggerConfig {
                 .paths(PathSelectors.regex("/api.*"))
                 .build()
                 .apiInfo(
-                    new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "2.0", null, null, null, null, Collections.emptyList())
+                    new ApiInfo(TITLE, DESCRIPTION, "2.0", null, null, null, null, Collections.emptyList())
                 );
     }
 
@@ -46,7 +49,7 @@ public class SwaggerConfig {
                 .paths(PathSelectors.regex("/api/v1.*"))
                 .build()
                 .apiInfo(
-                        new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "1.0", null, null, null, null, Collections.emptyList())
+                        new ApiInfo(TITLE, DESCRIPTION, "1.0", null, null, null, null, Collections.emptyList())
                 );
     }
 
@@ -59,7 +62,7 @@ public class SwaggerConfig {
                 .paths(PathSelectors.regex("/api/v2.*"))
                 .build()
                 .apiInfo(
-                        new ApiInfo("JES Jobs API", "REST API for the JES Jobs Service", "2.0", null, null, null, null, Collections.emptyList())
+                        new ApiInfo(TITLE, DESCRIPTION, "2.0", null, null, null, null, Collections.emptyList())
                 );
     }
 }

--- a/jobs-api-server/src/test/java/org/zowe/jobs/controller/JobsControllerTest.java
+++ b/jobs-api-server/src/test/java/org/zowe/jobs/controller/JobsControllerTest.java
@@ -68,7 +68,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @PrepareForTest({ ServletUriComponentsBuilder.class })
 public class JobsControllerTest extends ApiControllerTest {
 
-    private static final String ENDPOINT_ROOT = "/api/v2/jobs";
+    private static final String ENDPOINT_ROOT = "/api/v2/jobs/";
 
     @Mock
     private JobsService jobsService;
@@ -555,7 +555,7 @@ public class JobsControllerTest extends ApiControllerTest {
         mockJobUriConstruction(jobName, jobId, locationUri);
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/string").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .perform(post(ENDPOINT_ROOT + "string").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(request)))
             .andExpect(status().isCreated()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)))
@@ -615,7 +615,7 @@ public class JobsControllerTest extends ApiControllerTest {
         mockJobUriConstruction(jobName, jobId, locationUri);
 
         mockMvc
-            .perform(post(ENDPOINT_ROOT + "/dataset").contentType(MediaType.APPLICATION_JSON_VALUE)
+            .perform(post(ENDPOINT_ROOT + "dataset").contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(JsonUtils.convertToJsonString(request)))
             .andExpect(status().isCreated()).andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(content().string(JsonUtils.convertToJsonString(dummyJob)))
@@ -649,7 +649,7 @@ public class JobsControllerTest extends ApiControllerTest {
         PowerMockito.mockStatic(ServletUriComponentsBuilder.class);
         when(ServletUriComponentsBuilder.fromCurrentContextPath()).thenReturn(servletUriBuilder);
         UriComponentsBuilder uriBuilder = mock(UriComponentsBuilder.class);
-        when(servletUriBuilder.path(ENDPOINT_ROOT + "/{jobName}/{jobID}")).thenReturn(uriBuilder);
+        when(servletUriBuilder.path(ENDPOINT_ROOT + "{jobName}/{jobID}")).thenReturn(uriBuilder);
         UriComponents uriComponents = mock(UriComponents.class);
         when(uriBuilder.buildAndExpand(jobName, jobId)).thenReturn(uriComponents);
         when(uriComponents.toUri()).thenReturn(uriValue);

--- a/jobs-zowe-server-package/src/main/resources/apiml-static-registration.yaml.template
+++ b/jobs-zowe-server-package/src/main/resources/apiml-static-registration.yaml.template
@@ -15,13 +15,13 @@ services:
       - apiId: com.ibm.jobs.v1
         gatewayUrl: api/v1
         version: 1.0.0
-        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/v2/api-docs
-        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/swagger-ui.html
+        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/v2/api-docs?group=v1
+        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/swagger-ui.html?urls.primaryName=v1
       - apiId: com.ibm.jobs.v2
         gatewayUrl: api/v2
         version: 2.0.0
-        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/v2/api-docs
-        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/swagger-ui.html
+        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/v2/api-docs?group=v2
+        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_jobs_api_port}/swagger-ui.html?urls.primaryName=v2
 catalogUiTiles:
   jobs:
     title: z/OS Jobs services


### PR DESCRIPTION
Splits up the one large swagger doc that contains v1 and v2 APIs into 2 docs, one for v1 and one for v2. The one large doc is still available. Also changes the static registration so the API Catalog will display the doc for the correct version selected.

![Screen Shot 2022-05-16 at 10 53 45 AM](https://user-images.githubusercontent.com/14897740/168622222-47219574-c405-4837-a39d-c15e91ea1d31.png)
