### PR TITLE
explictly updating the snakeYaml version as latest versions of org.springdoc:springdoc-openapi-ui and spring-boot-starter-actuator pulls <1.31 versions of snakeYAML

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,6 +14,7 @@ ext {
     httpCoreVersion = '4.4.10'
     commonsCodecVersion = '1.15'
     slf4jVersion = "1.7.25"
+    snakeYaml = "1.31"
     jacksonCoreVersion = '2.13.2'
     jacksonDatabindVersion = '2.13.2.2'
     jsonPathVersion = "2.4.0"
@@ -27,6 +28,7 @@ ext {
             lombok                             : "org.projectlombok:lombok:${lombokVersion}",
             slf4j_simple                       : "org.slf4j:slf4j-simple:${slf4jVersion}",
             slf4j_api                          : "org.slf4j:slf4j-api:${slf4jVersion}",
+            snakeyaml                          : "org.yaml:snakeyaml:${snakeYaml}",
             spring_boot_gradle_plugin          : "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}",
             spring_boot_starter_actuator       : "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}",
             spring_boot_starter_parent         : "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}",

--- a/jobs-api-server/build.gradle
+++ b/jobs-api-server/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile libraries.guava
     compile libraries.logback_classic
     compile libraries.logback_core
+    compile libraries.snakeyaml
     compile libraries.spring_doc
     compile libraries.tomcat_annotations_api
     compile libraries.tomcat_embed_core

--- a/jobs-model/build.gradle
+++ b/jobs-model/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile libraries.gson
     compile libraries.logback_classic
     compile libraries.logback_core
+    compile libraries.snakeyaml
     compile libraries.spring_doc
     compile libraries.tomcat_annotations_api
     compile libraries.tomcat_embed_core

--- a/jobs-tests/build.gradle
+++ b/jobs-tests/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	compile libraries.commons_codec
 	compile libraries.gson
 	compile libraries.spring_messaging
+	compile libraries.snakeyaml
 	compile libraries.tomcat_annotations_api
 	compile libraries.tomcat_embed_core
 	compile libraries.tomcat_embed_el


### PR DESCRIPTION
explictly updating the snakeYaml version as latest versions of org.springdoc:springdoc-openapi-ui and spring-boot-starter-actuator pulls <1.31 versions of snakeYAML

Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>