### PR TITLE
upgraded springboot to 2.7.12 and snakeyaml to 2.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ group 'org.zowe.explorer.jobs'
 
 buildscript {
     ext {
-        licenseGradlePluginVerion = '0.13.1'
+        licenseGradlePluginVersion = '0.13.1'
     }
 
     ext.mavenRepositories = {
@@ -31,7 +31,7 @@ buildscript {
     dependencies {
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7'
         classpath 'net.researchgate:gradle-release:2.6.0'
-        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVerion}"
+        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVersion}"
         classpath 'org.owasp:dependency-check-gradle:3.3.4'
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
     }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,9 +1,8 @@
 ext {
-    springBootVersion = '2.5.14'
+    springBootVersion = '2.7.12'
     springSecurityVersion = '5.7.8!!'
     springFrameworkVersion = '5.3.27!!'
     springDocVersion = '1.6.9'
-    guavaVersion = '31.0.1-jre'
     logbackVersion = '1.2.9'
     lombokVersion = '1.18.20'
     mockitoCoreVersion = '2.23.4'
@@ -14,13 +13,12 @@ ext {
     httpCoreVersion = '4.4.14'
     commonsCodecVersion = '1.15'
     slf4jVersion = "1.7.25"
-    snakeYaml = "1.33"
+    snakeYaml = "2.0"
     jacksonCoreVersion = '2.14.1'
     jacksonDatabindVersion = '2.14.1'
     jsonPathVersion = "2.4.0"
     junitVersion = "4.13.1"
     restAssuredVersion = "4.3.0"
-    javaxValidationApiVersion= "2.0.1.Final"
     explorerApiCommonVersion = "2.0.21"
     tomcatVersion = "9.0.75"
 
@@ -75,7 +73,6 @@ ext {
             power_mock_junit4_rule             : "org.powermock:powermock-module-junit4-rule:${powerMockVersion}",
 
             gson                               : "com.google.code.gson:gson:${gsonVersion}",
-            guava                              : "com.google.guava:guava:${guavaVersion}",
             mockito_core                       : "org.mockito:mockito-core:${mockitoCoreVersion}",
 
             junit                              : "junit:junit:${junitVersion}",

--- a/jobs-api-server/build.gradle
+++ b/jobs-api-server/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     compile libraries.jackson_core
     compile libraries.jackson_databind
     compile libraries.gson
-    compile libraries.guava
     compile libraries.logback_classic
     compile libraries.logback_core
     compile libraries.snakeyaml
@@ -69,6 +68,6 @@ jar {
 }
 
 bootJar {
-    mainClassName = 'org.zowe.jobs.JesJobsApplication'
-    classifier = 'boot'
+    mainClass = 'org.zowe.jobs.JesJobsApplication'
+    archiveClassifier = 'boot'
 }


### PR DESCRIPTION
In order to resolve snakeyaml dependency upgrade to 2.0, springboot needs to be upgraded to 2.7.12, which prevents the use of deprecated values `mainClassName` and `classifier` in bootJar. Removed unused guava and javaxValidation dependencies.

Resolves:
https://github.com/zowe/security-reports/issues/353
https://github.com/zowe/security-reports/issues/350